### PR TITLE
Fix when page >= 1, there are always 0 results

### DIFF
--- a/routes/jobs.js
+++ b/routes/jobs.js
@@ -38,7 +38,7 @@ router.get('/:job_title', function(req, res, next) {
             }
         },
         {
-            $limit: 10,
+            $limit: page * 10 + 10,
         },
         {
             $skip: page * 10,


### PR DESCRIPTION
Since $limit = 10, then skip page * 10, there are only 10 data pass to skip ...