### PR TITLE
Fix mongodb version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "debug": "^2.2.0",
     "express": "^4.13.4",
     "express-mongo-db": "^2.0.3",
-    "mongodb": "^2.1.18",
+    "mongodb": "~2.1.18",
     "morgan": "^1.7.0",
     "request": "^2.72.0",
     "winston": "^2.2.0",


### PR DESCRIPTION
This will ensure the version up to 2.1.x, not 2.2.x.

I will revert this if more information about mongodb available.