### PR TITLE
When search, the key word should be escaped

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "debug": "^2.2.0",
     "express": "^4.13.4",
     "express-mongo-db": "^2.0.3",
+    "lodash": "^4.13.1",
     "mongodb": "~2.1.18",
     "morgan": "^1.7.0",
     "request": "^2.72.0",

--- a/routes/companies.js
+++ b/routes/companies.js
@@ -1,6 +1,7 @@
 var express = require('express');
 var router = express.Router();
 var HttpError = require('./errors').HttpError;
+var lodash = require('lodash');
 
 /*
  * GET /
@@ -18,7 +19,7 @@ router.get('/search', function(req, res, next) {
     } else {
         q = {
             $or: [
-                {name: new RegExp("^" + search)},
+                {name: new RegExp("^" + lodash.escapeRegExp(search))},
                 {id: search},
             ]
         };

--- a/routes/jobs.js
+++ b/routes/jobs.js
@@ -2,6 +2,7 @@ var express = require('express');
 var router = express.Router();
 var request = require('request');
 var HttpError = require('./errors').HttpError;
+var lodash = require('lodash');
 
 /*
  * GET /
@@ -17,7 +18,7 @@ router.get('/search', function(req, res, next) {
     if (search == "") {
         q = {isFinal: true};
     } else {
-        q = {des: new RegExp(search), isFinal: true};
+        q = {des: new RegExp(lodash.escapeRegExp(search)), isFinal: true};
     }
 
     console.log(q);


### PR DESCRIPTION
If you send `/search?key=.*`, it will be considered as regular expression command. Escape it for safety