### PR TITLE
docker-compose: make the facebook auth default

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,14 @@ MONGODB_URI=xxx npm start
 ```
 where xxx is your mongodb url
 
+If you would like to work around with the api, but want to skip the facebook auth, please add `SKIP_FACEBOOK_AUTH=1` to `docker-compose.yml` node env
+
 ## Test
 
 > 注意：請不要拿正式的資料庫做網址，測試將會清除一切資料
 > Notice: The test will clean all the data in db, please DON'T use db in production
+
+> When you run test, please make sure `SKIP_FACEBOOK_AUTH` is not set on env, or you may receive some error
 
 ```
 MONGODB_URI=xxx npm test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ node:
     command: npm start
     environment:
         - MONGODB_URI=mongodb://mongo/goodjob
-        - SKIP_FACEBOOK_AUTH=1
         - NODE_ENV=development
 mongo:
     image: mongo


### PR DESCRIPTION
The default skip-facebook-auth behavior is removed. Let the development more straightforward