### PR TITLE
增加 估計時薪 欄位

### DIFF
--- a/routes/workings_helper.js
+++ b/routes/workings_helper.js
@@ -96,7 +96,28 @@ function checkAndUpdateQuota(db, author) {
 
 }
 
+function calculateEstimatedHourlyWage(working) {
+    let estimated_hourly_wage;
+
+    if (working.salary.type === 'hour') {
+        estimated_hourly_wage = working.salary.amount;
+    } else if (working.day_real_work_time && working.salary.type === 'day') {
+        estimated_hourly_wage = working.salary.amount / working.day_real_work_time;
+    } else if (working.day_real_work_time && working.week_work_time) {
+        if (working.salary.type === 'month') {
+            estimated_hourly_wage = (working.salary.amount * 12) /
+                                    (52 * working.week_work_time - (12+7) * working.day_real_work_time);
+        } else if (working.salary.type === 'year') {
+            estimated_hourly_wage = working.salary.amount /
+                                    (52 * working.week_work_time - (12+7) * working.day_real_work_time);
+        }
+    }
+
+    return estimated_hourly_wage;
+}
+
 module.exports = {
     normalizeCompany,
     checkAndUpdateQuota,
+    calculateEstimatedHourlyWage,
 };

--- a/routes/workings_post.js
+++ b/routes/workings_post.js
@@ -356,10 +356,10 @@ function main(req, res, next) {
         let estimated_hourly_wage;
         if (working.salary.type === 'hour') {
             estimated_hourly_wage = working.salary.amount;
+        } else if (working.day_real_work_time && working.salary.type === 'day') {
+            estimated_hourly_wage = working.salary.amount / working.day_real_work_time;
         } else if (working.day_real_work_time && working.week_work_time) {
-            if (working.salary.type === 'day') {
-                estimated_hourly_wage = working.salary.amount / working.day_real_work_time;
-            } else if (working.salary.type === 'month') {
+            if (working.salary.type === 'month') {
                 estimated_hourly_wage = (working.salary.amount * 12) /
                                         (52 * working.week_work_time - (12+7) * working.day_real_work_time);
             } else if (working.salary.type === 'year') {

--- a/routes/workings_post.js
+++ b/routes/workings_post.js
@@ -352,6 +352,22 @@ function main(req, res, next) {
             type: req.custom.salary_type,
             amount: req.custom.salary_amount,
         };
+
+        let estimated_hourly_wage;
+        if (working.salary.type === 'hour') {
+            estimated_hourly_wage = working.salary.amount;
+        } else if (working.day_real_work_time && working.week_work_time) {
+            if (working.salary.type === 'day') {
+                estimated_hourly_wage = working.salary.amount / working.day_real_work_time;
+            } else if (working.salary.type === 'month') {
+                estimated_hourly_wage = (working.salary.amount * 12) /
+                                        (52 * working.week_work_time - (12+7) * working.day_real_work_time);
+            } else if (working.salary.type === 'year') {
+                estimated_hourly_wage = working.salary.amount /
+                                        (52 * working.week_work_time - (12+7) * working.day_real_work_time);
+            }
+        }
+        working.estimated_hourly_wage = estimated_hourly_wage;
     }
     if (working.is_currently_employed === 'no') {
         working.data_time = {

--- a/routes/workings_post.js
+++ b/routes/workings_post.js
@@ -353,21 +353,7 @@ function main(req, res, next) {
             amount: req.custom.salary_amount,
         };
 
-        let estimated_hourly_wage;
-        if (working.salary.type === 'hour') {
-            estimated_hourly_wage = working.salary.amount;
-        } else if (working.day_real_work_time && working.salary.type === 'day') {
-            estimated_hourly_wage = working.salary.amount / working.day_real_work_time;
-        } else if (working.day_real_work_time && working.week_work_time) {
-            if (working.salary.type === 'month') {
-                estimated_hourly_wage = (working.salary.amount * 12) /
-                                        (52 * working.week_work_time - (12+7) * working.day_real_work_time);
-            } else if (working.salary.type === 'year') {
-                estimated_hourly_wage = working.salary.amount /
-                                        (52 * working.week_work_time - (12+7) * working.day_real_work_time);
-            }
-        }
-        working.estimated_hourly_wage = estimated_hourly_wage;
+        working.estimated_hourly_wage = helper.calculateEstimatedHourlyWage(working);
     }
     if (working.is_currently_employed === 'no') {
         working.data_time = {

--- a/test/testWorkingsPost.js
+++ b/test/testWorkingsPost.js
@@ -633,10 +633,9 @@ describe('Workings 工時資訊', function() {
             it(`if salary_type is 'day' and has WorkingTime information
                 should have 'estimated_hourly_wage' field`, function(done) {
                 request(app).post('/workings')
-                    .send(generateWorkingTimeRelatedPayload({
+                    .send(generateAllPayload({
                         salary_type: 'day',
                         salary_amount: '10000',
-                        experience_in_year: '10',
                         day_real_work_time: '10',
                     }))
                     .expect(200)
@@ -650,10 +649,9 @@ describe('Workings 工時資訊', function() {
             it(`if salary_type is 'month' and has WorkingTime information
                 should have 'estimated_hourly_wage' field`, function(done) {
                 request(app).post('/workings')
-                    .send(generateWorkingTimeRelatedPayload({
+                    .send(generateAllPayload({
                         salary_type: 'month',
                         salary_amount: '10000',
-                        experience_in_year: '10',
                         day_real_work_time: '10',
                         week_work_time: '40',
                     }))
@@ -668,10 +666,9 @@ describe('Workings 工時資訊', function() {
             it(`if salary_type is 'year' and has WorkingTime information
                 should have 'estimated_hourly_wage' field`, function(done) {
                 request(app).post('/workings')
-                    .send(generateWorkingTimeRelatedPayload({
+                    .send(generateAllPayload({
                         salary_type: 'year',
                         salary_amount: '100000',
-                        experience_in_year: '10',
                         day_real_work_time: '10',
                         week_work_time: '40',
                     }))
@@ -998,3 +995,44 @@ function generateSalaryRelatedPayload(opt) {
     return payload;
 }
 
+function generateAllPayload(opt) {
+    opt = opt || {};
+    const valid = {
+        access_token: 'random',
+        job_title: 'test',
+        company_id: '00000001',
+        is_currently_employed: 'yes',
+        employment_type: 'full-time',
+        // Salary related
+        salary_type: 'year',
+        salary_amount: '10000',
+        experience_in_year: '10',
+        // WorkingTime related
+        week_work_time: '40',
+        overtime_frequency: '3',
+        day_promised_work_time: '8',
+        day_real_work_time: '10',
+    };
+
+    var payload = {};
+    for (let key in valid) {
+        if (opt[key]) {
+            if (opt[key] === -1) {
+                continue;
+            } else {
+                payload[key] = opt[key];
+            }
+        } else {
+            payload[key] = valid[key];
+        }
+    }
+    for (let key in opt) {
+        if (opt[key] === -1) {
+            continue;
+        } else {
+            payload[key] = opt[key];
+        }
+    }
+
+    return payload;
+}

--- a/test/testWorkingsPost.js
+++ b/test/testWorkingsPost.js
@@ -616,6 +616,73 @@ describe('Workings 工時資訊', function() {
                 });
             }
 
+            it(`if salary_type is 'hour' should have 'estimated_hourly_wage' field`, function(done) {
+                request(app).post('/workings')
+                    .send(generateSalaryRelatedPayload({
+                        salary_type: 'hour',
+                        salary_amount: '100',
+                    }))
+                    .expect(200)
+                    .expect(function(res) {
+                        assert.property(res.body.working, 'estimated_hourly_wage');
+                        assert.propertyVal(res.body.working, 'estimated_hourly_wage', 100);
+                    })
+                    .end(done);
+            });
+
+            it(`if salary_type is 'day' and has WorkingTime information
+                should have 'estimated_hourly_wage' field`, function(done) {
+                request(app).post('/workings')
+                    .send(generateWorkingTimeRelatedPayload({
+                        salary_type: 'day',
+                        salary_amount: '10000',
+                        experience_in_year: '10',
+                        day_real_work_time: '10',
+                    }))
+                    .expect(200)
+                    .expect(function(res) {
+                        assert.property(res.body.working, 'estimated_hourly_wage');
+                        assert.propertyVal(res.body.working, 'estimated_hourly_wage', 1000);
+                    })
+                    .end(done);
+            });
+
+            it(`if salary_type is 'month' and has WorkingTime information
+                should have 'estimated_hourly_wage' field`, function(done) {
+                request(app).post('/workings')
+                    .send(generateWorkingTimeRelatedPayload({
+                        salary_type: 'month',
+                        salary_amount: '10000',
+                        experience_in_year: '10',
+                        day_real_work_time: '10',
+                        week_work_time: '40',
+                    }))
+                    .expect(200)
+                    .expect(function(res) {
+                        assert.property(res.body.working, 'estimated_hourly_wage');
+                        assert.closeTo(res.body.working.estimated_hourly_wage, 63, 1);
+                    })
+                    .end(done);
+            });
+
+            it(`if salary_type is 'year' and has WorkingTime information
+                should have 'estimated_hourly_wage' field`, function(done) {
+                request(app).post('/workings')
+                    .send(generateWorkingTimeRelatedPayload({
+                        salary_type: 'year',
+                        salary_amount: '100000',
+                        experience_in_year: '10',
+                        day_real_work_time: '10',
+                        week_work_time: '40',
+                    }))
+                    .expect(200)
+                    .expect(function(res) {
+                        assert.property(res.body.working, 'estimated_hourly_wage');
+                        assert.closeTo(res.body.working.estimated_hourly_wage, 52, 1);
+                    })
+                    .end(done);
+            });
+
             it('salary_amount is required', function(done) {
                 request(app).post('/workings')
                     .send(generateSalaryRelatedPayload({


### PR DESCRIPTION
Solve #144 

``` salary_type === 'hour' ``` 比較特殊，使用者不需填寫工時部分也可以計算 "估計時薪"。
其他如果使用者同時有填寫 "薪資" and "工時" 的部分的話，則可以計算 "估計時薪"。
PS. 我有多寫一個 function 是結合 "薪資" and "工時" 的 Payload