### PR TITLE
使用者查詢資訊權限 API

### DIFF
--- a/middlewares/authentication.js
+++ b/middlewares/authentication.js
@@ -5,7 +5,7 @@ function cachedFacebookAuthenticationMiddleware(req, res, next) {
     const db = req.redis_client;
     let access_token;
     // POST or GET
-    if (req.body.access_token) {
+    if (req.body.access_token !== undefined) {
         access_token = req.body.access_token;
     } else {
         access_token = req.query.access_token;

--- a/middlewares/authentication.js
+++ b/middlewares/authentication.js
@@ -3,7 +3,13 @@ const HttpError = require('../libs/errors').HttpError;
 
 function cachedFacebookAuthenticationMiddleware(req, res, next) {
     const db = req.redis_client;
-    const access_token = req.body.access_token;
+    let access_token;
+    // POST or GET
+    if (req.body.access_token) {
+        access_token = req.body.access_token;
+    } else {
+        access_token = req.query.access_token;
+    }
 
     if (typeof access_token !== "string") {
         next(new HttpError('Unauthorized', 401));

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,6 +3,7 @@ const router = express.Router();
 
 const HttpError = require('../libs/errors').HttpError;
 const authentication = require('../middlewares/authentication');
+const authorization = require('../middlewares/authorization');
 const recommendation = require('../libs/recommendation');
 
 router.post('/me/recommendations', [
@@ -22,5 +23,15 @@ router.post('/me/recommendations', [
         });
     },
 ]);
+
+router.use('/me/permission/search', authentication.cachedFacebookAuthenticationMiddleware);
+router.use('/me/permission/search', authorization.cachedSearchPermissionAuthorizationMiddleware);
+// Middleware Error Handler
+router.use('/me/permission/search', function(err, req, res, next) {
+    res.send({hasSearchPermission: false});
+});
+router.get('/me/permission/search', function(req, res, next) {
+    res.send({hasSearchPermission: true});
+});
 
 module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -24,14 +24,16 @@ router.post('/me/recommendations', [
     },
 ]);
 
-router.use('/me/permission/search', authentication.cachedFacebookAuthenticationMiddleware);
-router.use('/me/permission/search', authorization.cachedSearchPermissionAuthorizationMiddleware);
-// Middleware Error Handler
-router.use('/me/permission/search', function(err, req, res, next) {
-    res.send({hasSearchPermission: false});
-});
-router.get('/me/permission/search', function(req, res, next) {
-    res.send({hasSearchPermission: true});
-});
+router.get('/me/permission/search', [
+    authentication.cachedFacebookAuthenticationMiddleware,
+    authorization.cachedSearchPermissionAuthorizationMiddleware,
+    // Middleware Error Handler
+    function(err, req, res, next) {
+        res.send({hasSearchPermission: false});
+    },
+    function(req, res, next) {
+        res.send({hasSearchPermission: true});
+    }
+]);
 
 module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -33,7 +33,7 @@ router.get('/me/permissions/search', [
     },
     function(req, res, next) {
         res.send({hasSearchPermission: true});
-    }
+    },
 ]);
 
 module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -24,7 +24,7 @@ router.post('/me/recommendations', [
     },
 ]);
 
-router.get('/me/permission/search', [
+router.get('/me/permissions/search', [
     authentication.cachedFacebookAuthenticationMiddleware,
     authorization.cachedSearchPermissionAuthorizationMiddleware,
     // Middleware Error Handler

--- a/test/testMePermissionSearch.js
+++ b/test/testMePermissionSearch.js
@@ -1,0 +1,78 @@
+const chai = require('chai');
+chai.use(require("chai-as-promised"));
+const assert = chai.assert;
+const sinon = require('sinon');
+require('sinon-as-promised');
+const request = require('supertest');
+
+const app = require('../app');
+const authentication = require('../libs/authentication');
+const authorization = require('../libs/authorization');
+
+describe('GET /me/permission/search 確認使用者查詢資訊權限', function() {
+    let sandbox;
+
+    beforeEach(function() {
+        sandbox = sinon.sandbox.create();
+    });
+
+    it('hasSearchPermission is true', function(done) {
+        const cachedFacebookAuthentication = sandbox.stub(authentication, 'cachedFacebookAuthentication')
+            .withArgs(sinon.match.object, 'fakeaccesstoken')
+            .resolves({id: '-1', name: 'LittleWhiteYA'});
+
+        const cachedSearchPermissionAuthorization = sandbox.stub(authorization, 'cachedSearchPermissionAuthorization')
+            .withArgs(sinon.match.object, sinon.match.object, {id: '-1', type: 'facebook'})
+            .resolves(true);
+
+        request(app).get('/me/permissions/search')
+            .query({
+                access_token: 'fakeaccesstoken',
+            })
+            .expect(200)
+            .expect(function(res) {
+                sinon.assert.calledOnce(cachedFacebookAuthentication);
+                sinon.assert.calledOnce(cachedSearchPermissionAuthorization);
+
+                assert.propertyVal(res.body, 'hasSearchPermission', true);
+            })
+            .end(done);
+    });
+
+    it('hasSearchPermission is false if facebook auth fail', function(done) {
+        sandbox.stub(authentication, 'cachedFacebookAuthentication').rejects();
+
+        request(app).get('/me/permissions/search')
+            .query({
+                access_token: 'fakeaccesstoken',
+            })
+            .expect(200)
+            .expect(function(res) {
+                assert.propertyVal(res.body, 'hasSearchPermission', false);
+            })
+            .end(done);
+    });
+
+    it('hasSearchPermission is false if authorization fail', function(done) {
+        const cachedFacebookAuthentication = sandbox.stub(authentication, 'cachedFacebookAuthentication')
+            .withArgs(sinon.match.object, 'fakeaccesstoken')
+            .resolves({id: '-1', name: 'LittleWhiteYA'});
+        sandbox.stub(authorization, 'cachedSearchPermissionAuthorization').rejects();
+
+        request(app).get('/me/permissions/search')
+            .query({
+                access_token: 'fakeaccesstoken',
+            })
+            .expect(200)
+            .expect(function(res) {
+                sinon.assert.calledOnce(cachedFacebookAuthentication);
+
+                assert.propertyVal(res.body, 'hasSearchPermission', false);
+            })
+            .end(done);
+    });
+
+    afterEach(function() {
+        sandbox.restore();
+    });
+});


### PR DESCRIPTION
issue #157
- [x] API
- [x] test

我選擇使用 Error handling middleware，在經過 Authetication and Authorization 的時候，如果有 Error 產生的話，next 後會直接跳進 Error handling middleware，並 `res.send({hasSearchPermission: false})`
如果沒有 Error 則到最後 endpoint 會 `res.send({hasSearchPermission: true})`