### PR TITLE
排序資料時，如果該欄位沒有值，應該要排在最後面 bug

### DIFF
--- a/routes/middleware.js
+++ b/routes/middleware.js
@@ -13,10 +13,6 @@ function sort_by(req, res, next) {
     }
 
     req.query.sort_by = sort_by;
-    req.query_field = {};
-    req.query_field[sort_by] = {
-        $exists: true,
-    };
     req.sort_by = {};
     req.sort_by[sort_by] = order;
     next();

--- a/routes/middleware.js
+++ b/routes/middleware.js
@@ -12,6 +12,11 @@ function sort_by(req, res, next) {
         return;
     }
 
+    req.query.sort_by = sort_by;
+    req.query_field = {};
+    req.query_field[sort_by] = {
+        $exists: true,
+    };
     req.sort_by = {};
     req.sort_by[sort_by] = order;
     next();

--- a/routes/workings.js
+++ b/routes/workings.js
@@ -43,6 +43,16 @@ router.get('/', function(req, res, next) {
 
         return collection.find(query, opt).sort(req.sort_by).skip(limit * page).limit(limit).toArray();
     }).then(function(results) {
+        // move undefined data to the bottom of array
+        const sort_by = req.query.sort_by || 'created_at';
+        if (results.length > 0 && results[0][sort_by] === undefined) {
+            let undefined_count = 1;
+            for (let idx=1; idx<results.length && results[idx][sort_by] === undefined; ++idx, ++undefined_count);
+
+            const undefined_arr = results.splice(0, undefined_count);
+            results = results.concat(undefined_arr);
+        }
+
         data.time_and_salary = results;
 
         res.send(data);

--- a/routes/workings.js
+++ b/routes/workings.js
@@ -47,7 +47,9 @@ router.get('/', function(req, res, next) {
         const sort_by = req.query.sort_by || 'created_at';
         if (results.length > 0 && results[0][sort_by] === undefined) {
             let undefined_count = 1;
-            for (let idx=1; idx<results.length && results[idx][sort_by] === undefined; ++idx, ++undefined_count);
+            for (let idx=1; idx<results.length && results[idx][sort_by] === undefined; ++idx) {
+                ++undefined_count;
+            }
 
             const undefined_arr = results.splice(0, undefined_count);
             results = results.concat(undefined_arr);

--- a/test/testWorkings.js
+++ b/test/testWorkings.js
@@ -248,10 +248,38 @@ describe('Workings 工時資訊', function() {
                         }
                     }
 
+                    // bug
                     for (let idx=1; idx<undefined_start_idx; ++idx) {
                         assert(workings[idx][sort_field] >= workings[idx-1][sort_field]);
                     }
                     for (let idx=undefined_start_idx; idx<workings.length; ++idx) {
+                        assert.isUndefined(workings[idx][sort_field]);
+                    }
+                })
+                .end(done);
+        });
+
+        it(`sort_by ascending order with SORT_FIELD 'week_work_time'`, function(done) {
+            sandbox.stub(authenticationLib, 'cachedFacebookAuthentication')
+                .resolves({id: '-1', name: 'LittleWhiteYA'});
+            sandbox.stub(authorizationLib, 'cachedSearchPermissionAuthorization').resolves();
+
+            request(app).get('/workings')
+                .query({
+                    sort_by: 'week_work_time',
+                    order: 'ascending',
+                    access_token: 'faketoken',
+                })
+                .expect(200)
+                .expect(function(res) {
+                    const sort_field = 'week_work_time';
+                    const workings = res.body.time_and_salary;
+
+                    let undefined_idx = 3;
+                    for (let idx=1; idx<undefined_idx; ++idx) {
+                        assert(workings[idx][sort_field] >= workings[idx-1][sort_field]);
+                    }
+                    for (let idx=undefined_idx; idx<workings.length; ++idx) {
                         assert.isUndefined(workings[idx][sort_field]);
                     }
                 })

--- a/test/testWorkings.js
+++ b/test/testWorkings.js
@@ -239,21 +239,9 @@ describe('Workings 工時資訊', function() {
                     // sort_field default is field 'created_at'
                     const sort_field = 'created_at';
                     const workings = res.body.time_and_salary;
-                    let undefined_start_idx = workings.length;
 
-                    for (let idx in workings) {
-                        if (workings[idx][sort_field] === undefined) {
-                            undefined_start_idx = idx;
-                            break;
-                        }
-                    }
-
-                    // bug
-                    for (let idx=1; idx<undefined_start_idx; ++idx) {
+                    for (let idx=1; idx<workings.length; ++idx) {
                         assert(workings[idx][sort_field] >= workings[idx-1][sort_field]);
-                    }
-                    for (let idx=undefined_start_idx; idx<workings.length; ++idx) {
-                        assert.isUndefined(workings[idx][sort_field]);
                     }
                 })
                 .end(done);

--- a/test/testWorkings.js
+++ b/test/testWorkings.js
@@ -274,6 +274,30 @@ describe('Workings 工時資訊', function() {
                 .end(done);
         });
 
+        it(`欄位是 undefined 的資料全部會被放在 defined 的資料的後面`, function(done) {
+            sandbox.stub(authenticationLib, 'cachedFacebookAuthentication')
+                .resolves({id: '-1', name: 'LittleWhiteYA'});
+            sandbox.stub(authorizationLib, 'cachedSearchPermissionAuthorization').resolves();
+
+            request(app).get('/workings')
+                .query({
+                    sort_by: 'week_work_time',
+                    order: 'ascending',
+                    access_token: 'faketoken',
+                    limit: '2',
+                    page: '1',
+                })
+                .expect(200)
+                .expect(function(res) {
+                    const sort_field = 'week_work_time';
+                    const workings = res.body.time_and_salary;
+
+                    assert.isDefined(workings[0][sort_field]);
+                    assert.isUndefined(workings[1][sort_field]);
+                })
+                .end(done);
+        });
+
         after(function() {
             return db.collection('workings').remove({});
         });


### PR DESCRIPTION
issue #176 
我剛開始嘗試使用對 mongodb 做兩次 query 的方式達到要求，但是發現這樣會必須處理 limit、page 的問題，而且 query 還必須要手動自己刻，程式碼覺得會變得有點醜，所以我後來選擇另外一種方法 => 直接對 query 出來的 results 做 array elements 的搬移
我覺得會比做兩次 query 要來的好而且簡單
API and test 部分都已經做好修改