### PR TITLE
[WIP] 點讚留言API  (尚未寫測試)

### DIFF
--- a/app.js
+++ b/app.js
@@ -51,6 +51,7 @@ app.use('/jobs', require('./routes/jobs'));
 app.use('/experiences', require('./routes/experiences'));
 app.use('/interview_experiences', require('./routes/interview_experiences'));
 app.use('/work_experiences', require('./routes/work_experiences'));
+app.use('/replies/', require('./routes/likes'));
 
 const corsOption = {
     origin: [

--- a/database/migrations/create-likes-collection.js
+++ b/database/migrations/create-likes-collection.js
@@ -1,0 +1,5 @@
+module.exports = (db) => {
+    return Promise.all([
+        db.collection('likes').createIndex({user: 1, ref:1}, {unique: true}),
+    ]);
+}

--- a/database/migrations/index.js
+++ b/database/migrations/index.js
@@ -1,5 +1,6 @@
 module.exports = [
     'create-companies-collection',
     'create-recommendations-collection',
+    'create-likes-collection',
     'calc-data-time',
 ];

--- a/database/migrations/index.js
+++ b/database/migrations/index.js
@@ -1,6 +1,6 @@
 module.exports = [
     'create-companies-collection',
     'create-recommendations-collection',
-    'create-likes-collection',
     'calc-data-time',
+    'create-likes-collection',
 ];

--- a/routes/likes.js
+++ b/routes/likes.js
@@ -1,0 +1,70 @@
+const express = require('express');
+const router = express.Router();
+const HttpError = require('../libs/errors').HttpError;
+const facebook = require('../libs/facebook');
+const ObjectId = require('mongodb').ObjectId;
+const winston = require('winston');
+
+/*
+ * When developing, you can set environment to skip facebook auth
+ */
+if (! process.env.SKIP_FACEBOOK_AUTH) {
+    router.post('/', function(req, res, next) {
+        var access_token = req.body.access_token;
+
+        facebook.accessTokenAuth(access_token).then(function(facebook) {
+            winston.info("facebook auth success", {access_token: access_token, ip: req.ip, ips: req.ips});
+
+            req.custom.facebook = facebook;
+            next();
+        }).catch(function(err) {
+            winston.info("facebook auth fail", {access_token: access_token, ip: req.ip, ips: req.ips});
+
+            next(new HttpError("Unauthorized", 401));
+        });
+    });
+}
+
+router.post('/:id/likes', (req, res, next) => {
+    winston.info(req.originalUrl, {query: req.query, ip: req.ip, ips: req.ips});
+
+    const id =  req.params.id;
+    if(typeof id === 'undefined'){
+        next(new HttpError('id error'), 422);
+        return;
+    }
+
+    const author = {};
+    console.log(req.custom);
+    if (req.custom && req.custom.facebook) {
+        author.id = req.custom.facebook.id,
+        author.name = req.custom.facebook.name,
+        author.type = "facebook";
+    } else {
+        author.id = "-1";
+        author.type = "test";
+    }
+
+    const collection = req.db.collection('likes');
+    const data = {
+        "user": author,
+        "ref": {
+            "$ref": "replies",
+            "$id": new ObjectId(id),
+        }
+    };
+
+    //Notice: please ensure unique index has been applied on (user, ref)
+    collection.insert(data).then(results => {
+        winston.info("user likes a reply successfully", {id: results.insertedIds[1], ip: req.ip, ips: req.ips});
+        res.send({success: true});
+    }).catch(err => {
+        if(err.code === 11000){  //E11000 duplicate key error
+            next(new HttpError("已重複按讚！", 403));
+        } else {
+            next(err);
+        }
+    })
+});
+
+module.exports = router;

--- a/routes/likes.js
+++ b/routes/likes.js
@@ -30,12 +30,11 @@ router.post('/:id/likes', (req, res, next) => {
 
     const id =  req.params.id;
     if(typeof id === 'undefined'){
-        next(new HttpError('id error'), 422);
+        next(new HttpError('id error', 422));
         return;
     }
 
     const author = {};
-    console.log(req.custom);
     if (req.custom && req.custom.facebook) {
         author.id = req.custom.facebook.id,
         author.name = req.custom.facebook.name,


### PR DESCRIPTION
to solve: #195 

- [x] 建 unique index 於 likes這個collection的 (ref, user) 欄位上
- [x] 利用unique index，直接 insert 一個 like的document，重複的話會跳 E11000 duplicate key error 的錯誤。
- [ ] 檢查 reply id 是否存在
- [ ] 撰寫測試


To discuss:
1. 我是用error.code = 11000 去偵測是不是duplicate key error，不確定有沒有更好的方法?
2. 已經按讚又去按讚的情況下，http status code我是設定403，OK? 


Notes:
1. duplicate key error發生的時候，error的物件會長這樣:
```
{ 
    "message":"E11000 duplicate key error collection: goodjob.likes index: user_1_ref_1 dup key: { : { id: \"-1\", type: \"test\" }, : { $ref: \"replies\", $id: ObjectId('313233343536373839303132') } }",
    "error":{ 
          "code":11000,
          "index":0,
          "errmsg":"E11000 duplicate key error collection: goodjob.likes index: user_1_ref_1 dup key: { : { id: \"-1\", type: \"test\" }, : { $ref: \"replies\", $id: ObjectId('313233343536373839303132') } }",
           "op":{
                 "user":{"id":"-1","type":"test"},
                 "ref":{"$ref":"replies","$id":"313233343536373839303132"},
                 "_id":"58db785521d22c0f00e2ec8a"
          }
     }
}
```

2. 成功按讚的話，results會長這樣:
```
{ 
    result: { ok: 1, n: 1 },
    ops: [ { user: [Object], ref: [Object], _id: 58db7cc54269180f00af0c1c } ],
    insertedCount: 1,
    insertedIds: [ , 58db7cc54269180f00af0c1c ] 
}
```