### PR TITLE
[dev/3.x] 修正同時 checkAndUpdateQuota 造成的問題

### DIFF
--- a/routes/workings_helper.js
+++ b/routes/workings_helper.js
@@ -84,7 +84,7 @@ function checkAndUpdateQuota(db, author) {
                 upsert: true,
                 returnOriginal: false,
             }
-        )
+        );
     }
 
     function decrementWithoutError() {

--- a/routes/workings_helper.js
+++ b/routes/workings_helper.js
@@ -70,30 +70,46 @@ function checkAndUpdateQuota(db, author) {
     const collection = db.collection('authors');
     const quota = 5;
 
-    return collection.findAndModify(
-        {
-            _id: author,
-            queries_count: {$lt: quota},
-        },
-        [
-        ],
-        {
-            $inc: { queries_count: 1 },
-        },
-        {
-            upsert: true,
-            new: true,
-        }
-    ).then(result => {
-        if (result.value.queries_count > quota) {
-            throw new HttpError(`您已經上傳${quota}次，已達最高上限`, 429);
-        }
+    const filter = {
+        _id: author,
+    };
 
-        return result.value.queries_count;
-    }, err => {
-        throw new HttpError(`您已經上傳${quota}次，已達最高上限`, 429);
-    });
+    function increment() {
+        return collection.findOneAndUpdate(
+            filter,
+            {
+                $inc: { queries_count: 1 },
+            },
+            {
+                upsert: true,
+                returnOriginal: false,
+            }
+        )
+    }
 
+    function decrementWithoutError() {
+        return collection.updateOne(filter, {$inc: { queries_count: -1 }})
+            .catch(() => {});
+    }
+
+    return increment()
+        .catch(err => {
+            if (err.code === 11000) { // E11000 duplicate key err
+                return increment();
+            }
+
+            throw new HttpError(`上傳資料發生點問題`, 500);
+        })
+        .then(result => {
+            if (result.value.queries_count > quota) {
+                return decrementWithoutError()
+                    .then(() => {
+                        throw new HttpError(`您已經上傳${quota}次，已達最高上限`, 429);
+                    });
+            }
+
+            return result.value.queries_count;
+        });
 }
 
 function calculateEstimatedHourlyWage(working) {


### PR DESCRIPTION
1. `findAndModify` with `upsert = true` 可能產生錯誤

    當 filter 找到 0 筆資料時，`upsert = true` 會引發插入資料

    這之間如果有其它同 _id 的資料被插入，

    則會造成 duplicate key error

    於是資料筆數如果是 0，仍然會看到錯誤

2. 當發生 duplicate key error 時，再執行一次插入，理論上就會插入成功