### PR TITLE
Get /experiences (補1 - 多回傳like_count)

### DIFF
--- a/models/experience_model.js
+++ b/models/experience_model.js
@@ -42,6 +42,10 @@ class ExperienceModel {
             author: 0,
             education: 0,
             experience_in_year: 0,
+            interview_time: 0,
+            interview_qas: 0,
+            interview_result: 0,
+            interview_sensitive_questions: 0,
         };
 
         return this.collection.find(query, opt).sort(sort).skip(skip).limit(limit).toArray()

--- a/models/experience_model.js
+++ b/models/experience_model.js
@@ -41,6 +41,7 @@ class ExperienceModel {
         const opt = {
             author: 0,
             education: 0,
+            experience_in_year: 0,
         };
 
         return this.collection.find(query, opt).sort(sort).skip(skip).limit(limit).toArray()

--- a/routes/experiences/index.js
+++ b/routes/experiences/index.js
@@ -8,15 +8,13 @@ const ExperienceModel = require('../../models/experience_model');
 
 /**
  * Get /experiences api
- * @param {object} req.query
- *  - {
- *      search_query = "GoodJob".
- *      search_by = "compnay",
- *      sort = "created_at",
- *      page = 0,
- *      limit = 20,
- *      type = "interview"
- *  }
+ * @param {string} search_query - "goodjob"
+ * @param {string} search_by - "compnay"/"job_title"
+ * @param {string} sort - "created_at"
+ * @param {string} page - "0"
+ * @param {string} limit - "20"
+ * @param {string} type - "interview"/"work"
+ *
  * @returns {object}
  *  - {
  *      total_pages : 1,

--- a/test/api/experiences/testExperiences.js
+++ b/test/api/experiences/testExperiences.js
@@ -314,7 +314,7 @@ describe('Experiences 面試和工作經驗資訊', function() {
                 .expect(422);
         });
 
-        it('沒有query的搜尋，驗驗面試經驗回傳欄位', function() {
+        it('沒有query的搜尋，驗證『面試經驗』回傳欄位', function() {
             return request(app).get('/experiences')
                 .expect(200)
                 .expect(function(res) {
@@ -343,7 +343,7 @@ describe('Experiences 面試和工作經驗資訊', function() {
                 });
         });
 
-        it('沒有query的搜尋，驗驗工作經驗回傳欄位', function() {
+        it('沒有query的搜尋，驗證『工作經驗』回傳欄位', function() {
             return request(app).get('/experiences')
                 .expect(200)
                 .expect(function(res) {

--- a/test/api/experiences/testExperiences.js
+++ b/test/api/experiences/testExperiences.js
@@ -43,10 +43,24 @@ describe('Experiences 面試和工作經驗資訊', function() {
                     content: "被洗到好慘",
                 }],
                 education: "碩士",
+                interview_time: {
+                    year: 10,
+                    month: 1,
+                },
+                interview_qas: [
+                    { question: "What your name?", answer: "I'm Mark" },
+                ],
+                interview_result: "Sorry ~ ",
+                interview_sensitive_questions: [
+                    "Are you a yacht boy ?",
+                ],
+                salary: {
+                    type: "year",
+                    amount: 1000000,
+                },
                 status: "draft",
                 like_count: 1,
                 reply_count: 1,
-                share_count: 1,
             }).then(function(result) {
                 testId = result.ops[0]._id;
             });
@@ -73,16 +87,15 @@ describe('Experiences 面試和工作經驗資訊', function() {
         before('Seeding some experiences', function() {
             return db.collection('experiences').insertMany([
                 {
+                    type: "interview",
                     created_at: new Date("2017-03-20T10:00:00.929Z"),
                     company: {
                         name: "GOODJOB1",
                         id: "123",
                     },
                     area: "台北",
+                    title: "Good面試",
                     job_title: "SW ENGINEER",
-                    interview_time_year: "2017",
-                    interview_time_month: "3",
-                    // interview_result: ???,
                     overall_rating: "5",
                     sections: [
                         {
@@ -90,23 +103,42 @@ describe('Experiences 面試和工作經驗資訊', function() {
                             content: "很開心",
                         },
                     ],
+                    interview_time: {
+                        year: 10,
+                        month: 1,
+                    },
+                    interview_qas: [
+                        { question: "What your name?", answer: "I'm Mark" },
+                    ],
+                    interview_result: "Sorry ~ ",
+                    interview_sensitive_questions: [
+                        "Are you a yacht boy ?",
+                    ],
+                    salary: {
+                        type: "year",
+                        amount: 1000000,
+                    },
                     experience_in_year: "1",
                     education: "bachelor",
                     salary_type: "month",
                     salary_amount: "66666",
+                    like_count: 1,
+                    reply_count: 1,
                 },
                 {
+                    type: "work",
+                    author: {
+                        type: "facebook",
+                        _id: "abcde",
+                    },
                     created_at: new Date("2017-03-21T10:00:00.929Z"),
                     company: {
                         name: "GOODJOB2",
                         id: "123",
                     },
-                    area: "台北",
+                    region: "台北",
                     job_title: "ENGINEER",
-                    interview_time_year: "2017",
-                    interview_time_month: "3",
-                    // interview_result: ???,
-                    overall_rating: "5",
+                    title: "Facebook Work",
                     sections: [
                         {
                             subtitle: "面試過程",
@@ -115,8 +147,23 @@ describe('Experiences 面試和工作經驗資訊', function() {
                     ],
                     experience_in_year: "1",
                     education: "bachelor",
-                    salary_type: "month",
-                    salary_amount: "66666",
+                    is_currently_employed: "yes",
+                    job_ending_time: {
+                        year: 2017,
+                        month: 1,
+                    },
+                    salary: {
+                        type: "month",
+                        amount: 100000,
+                    },
+                    week_work_time: 40,
+                    recommend_to_others: "yes",
+                    data_time: {
+                        year: 2017,
+                        month: 1,
+                    },
+                    like_count: 1,
+                    reply_count: 1,
                 },
                 {
                     created_at: new Date("2017-03-22T10:00:00.929Z"),
@@ -265,6 +312,63 @@ describe('Experiences 面試和工作經驗資訊', function() {
                     sort: "xxxxx",
                 })
                 .expect(422);
+        });
+
+        it('沒有query的搜尋，驗驗面試經驗回傳欄位', function() {
+            return request(app).get('/experiences')
+                .expect(200)
+                .expect(function(res) {
+                    assert.property(res.body, 'total_pages');
+                    assert.property(res.body, 'page');
+                    assert.property(res.body, 'experiences');
+                    const experience = res.body.experiences[2];
+                    assert.property(experience, '_id');
+                    assert.property(experience, 'type');
+                    assert.property(experience, 'created_at');
+                    assert.property(experience, 'company');
+                    assert.property(experience, 'job_title');
+                    assert.property(experience, 'title');
+                    assert.property(experience, 'preview');
+                    assert.property(experience, 'like_count');
+                    assert.property(experience, 'reply_count');
+
+                    assert.notProperty(experience, 'author');
+                    assert.notProperty(experience, 'sections');
+                    assert.notProperty(experience, 'experience_in_year');
+                    assert.notProperty(experience, 'education');
+                    assert.notProperty(experience, 'interview_time');
+                    assert.notProperty(experience, 'interview_qas');
+                    assert.notProperty(experience, 'interview_result');
+                    assert.notProperty(experience, 'interview_sensitive_questions');
+                });
+        });
+
+        it('沒有query的搜尋，驗驗工作經驗回傳欄位', function() {
+            return request(app).get('/experiences')
+                .expect(200)
+                .expect(function(res) {
+                    assert.property(res.body, 'total_pages');
+                    assert.property(res.body, 'page');
+                    assert.property(res.body, 'experiences');
+                    const experience = res.body.experiences[1];
+                    assert.property(experience, '_id');
+                    assert.property(experience, 'type');
+                    assert.property(experience, 'created_at');
+                    assert.property(experience, 'company');
+                    assert.property(experience, 'region');
+                    assert.property(experience, 'job_title');
+                    assert.property(experience, 'title');
+                    assert.property(experience, 'preview');
+                    assert.property(experience, 'salary');
+                    assert.property(experience, 'week_work_time');
+                    assert.property(experience, 'like_count');
+                    assert.property(experience, 'reply_count');
+
+                    assert.notProperty(experience, 'author');
+                    assert.notProperty(experience, 'sections');
+                    assert.notProperty(experience, 'experience_in_year');
+                    assert.notProperty(experience, 'education');
+                });
         });
         after(function() {
             return db.collection('experiences').remove({});

--- a/test/api/experiences/testExperiences.js
+++ b/test/api/experiences/testExperiences.js
@@ -323,7 +323,7 @@ describe('Experiences 面試和工作經驗資訊', function() {
                     assert.property(res.body, 'experiences');
                     const experience = res.body.experiences[2];
                     assert.property(experience, '_id');
-                    assert.property(experience, 'type');
+                    assert.propertyVal(experience, 'type', 'interview');
                     assert.property(experience, 'created_at');
                     assert.property(experience, 'company');
                     assert.property(experience, 'job_title');
@@ -352,7 +352,7 @@ describe('Experiences 面試和工作經驗資訊', function() {
                     assert.property(res.body, 'experiences');
                     const experience = res.body.experiences[1];
                     assert.property(experience, '_id');
-                    assert.property(experience, 'type');
+                    assert.propertyVal(experience, 'type', 'work');
                     assert.property(experience, 'created_at');
                     assert.property(experience, 'company');
                     assert.property(experience, 'region');


### PR DESCRIPTION
#251
本次修改點
1. 修改route的 Get /experiences 的註解寫法。
2. 修改mongodb find opt.
3. 補驗證面試經驗與工作經驗欄位回傳測試。

我發覺在experience model 中我mongodb find opt 是用 `{ author:0 , education :0 }`這種不顯示欄位的選法，所以說如果mongodb中有存放`like_count`就會回傳。