### PR TITLE
POST /experiences/:id/likes 經驗按讚 API(補1 - 新增讚時同時也要將experiences like_count修改 )

### DIFF
--- a/models/experience_model.js
+++ b/models/experience_model.js
@@ -132,7 +132,7 @@ class ExperienceModel {
     }
 
     /**
-     * 使用experience Id 來取得單篇文章
+     * 根據id更新experience的reply_count
      * @param   {string} id - erperiences's id
      * @returns {Promise}
      *  - resolved : {
@@ -144,6 +144,28 @@ class ExperienceModel {
      *  - reject : ObjectNotExistError/Default Error
      */
     incrementReplyCount(id) {
+        const field = "reply_count";
+        return this._incrementField(field, id);
+    }
+
+    /**
+     * 根據id更新experience的like_count
+     * @param   {string} id - erperiences's id
+     * @returns {Promise}
+     *  - resolved : {
+     *        value: {
+     *            like_count: Current Like Count (after increment 1)
+     *        }
+     *    }
+     *
+     *  - reject : ObjectNotExistError/Default Error
+     */
+    incrementLikeCount(id) {
+        const field = "like_count";
+        return this._incrementField(field, id);
+    }
+
+    _incrementField(field, id) {
         if (!mongo.ObjectId.isValid(id)) {
             throw new ObjectNotExistError("該文章不存在");
         }
@@ -151,12 +173,12 @@ class ExperienceModel {
         return this.collection.findOneAndUpdate({_id: new mongo.ObjectId(id)},
             {
                 $inc: {
-                    reply_count: 1,
+                    [field]: 1,
                 },
             },
             {
                 projection: {
-                    reply_count: 1,
+                    [field]: 1,
                 },
                 returnOriginal: false,
             }

--- a/routes/experiences/likes.js
+++ b/routes/experiences/likes.js
@@ -2,6 +2,7 @@ const express = require('express');
 const winston = require('winston');
 const router = express.Router();
 const LikeModel = require('../../models/like_model');
+const ExperienceModel = require('../../models/experience_model');
 const authentication = require('../../middlewares/authentication');
 const ObjectNotExistError = require('../../libs/errors').ObjectNotExistError;
 const HttpError = require('../../libs/errors').HttpError;
@@ -29,8 +30,11 @@ router.post('/:id/likes', [
         };
         const experience_id = req.params.id;
         const like_model = new LikeModel(req.db);
+        const experience_model = new ExperienceModel(req.db);
 
         like_model.createLikeToExperience(experience_id, user).then((result) => {
+            return experience_model.incrementLikeCount(experience_id);
+        }).then((result) => {
             res.send({
                 success: true,
             });

--- a/test/api/experiences/testLikes.js
+++ b/test/api/experiences/testLikes.js
@@ -1,4 +1,5 @@
 const assert = require('chai').assert;
+const mongo = new require('mongodb');
 const request = require('supertest');
 const app = require('../../../app');
 const MongoClient = require('mongodb').MongoClient;
@@ -92,16 +93,63 @@ describe('Experience Likes Test', function() {
                     access_token: 'fakeaccesstoken',
                 })
                 .then((res) => {
-                    return request(app)
-                        .get('/experiences/' + experience_id)
-                        .send({
-                            access_token: 'fakeaccesstoken',
-                        })
-                        .expect(200)
-                        .expect((res ) => {
-                            const experience = res.body;
-                            assert.equal(experience.like_count, 1);
+                    return db.collection("experiences")
+                    .find({ _id: new mongo.ObjectId(experience_id)})
+                    .toArray()
+                    .then((result) => {
+                        assert.equal(result[0].like_count, 1);
+                    });
+                });
+        });
+
+        it('Post like 2 times (same user) and get experience , and expected experience like_count will 1 ', function() {
+            const uri = '/experiences/' + experience_id + '/likes';
+            return request(app).post(uri)
+                .send({
+                    access_token: 'fakeaccesstoken',
+                })
+                .then((res) => {
+                    return request(app).post(uri)
+                    .send({
+                        access_token: 'fakeaccesstoken',
+                    });
+                })
+                .then((res) => {
+                    return db.collection("experiences")
+                        .find({ _id: new mongo.ObjectId(experience_id)})
+                        .toArray();
+                })
+                .then((result) => {
+                    assert.equal(result[0].like_count, 1);
+                });
+        });
+
+        it('Post like 2 times(different user) and get experience , and expected experience like_count will 2 ', function() {
+            const uri = '/experiences/' + experience_id + '/likes';
+            return request(app).post(uri)
+                .send({
+                    access_token: 'fakeaccesstoken',
+                })
+                .then((res) => {
+                    sandbox.restore();
+                    sandbox.stub(authentication, 'cachedFacebookAuthentication')
+                        .withArgs(sinon.match.object, 'fakeaccesstoken')
+                        .resolves({
+                            id: '-2',
+                            name: 'markLin002',
                         });
+                    return request(app).post(uri)
+                    .send({
+                        access_token: 'fakeaccesstoken',
+                    });
+                })
+                .then((res) => {
+                    return db.collection("experiences")
+                        .find({ _id: new mongo.ObjectId(experience_id)})
+                        .toArray();
+                })
+                .then((result) => {
+                    assert.equal(result[0].like_count, 2);
                 });
         });
 

--- a/test/api/experiences/testLikes.js
+++ b/test/api/experiences/testLikes.js
@@ -38,6 +38,7 @@ describe('Experience Likes Test', function() {
                     _id: "123",
                 },
                 status: "published",
+                like_count: 0,
             }).then(function(result) {
                 experience_id = result.insertedId.toString();
             });
@@ -83,6 +84,25 @@ describe('Experience Likes Test', function() {
             return request(app)
                     .post('/experiences/' + experience_id + '/likes')
                     .expect(401);
+        });
+
+        it('Post like and get experience , and expected experience like_count will 1 ', function() {
+            return request(app).post('/experiences/' + experience_id + '/likes')
+                .send({
+                    access_token: 'fakeaccesstoken',
+                })
+                .then((res) => {
+                    return request(app)
+                        .get('/experiences/' + experience_id)
+                        .send({
+                            access_token: 'fakeaccesstoken',
+                        })
+                        .expect(200)
+                        .expect((res ) => {
+                            const experience = res.body;
+                            assert.equal(experience.like_count, 1);
+                        });
+                });
         });
 
         afterEach(function() {


### PR DESCRIPTION
#244 
修改部份.

1. 在experience model 中新增`incrementLikeCount`，由於大部份於`incrementReplyCount`相同，因此在相同的部份拉出個`Extract Method`取名為`_incrementField`。
2. 新增『在新增完經驗的讚後，再去取得經驗文章，驗證它的`like_count`是否有增加』的測試。
3. 註解修改。