### PR TITLE
DELETE /experiences/:id/likes 移除單篇經驗的讚 API

### DIFF
--- a/models/experience_like_model.js
+++ b/models/experience_like_model.js
@@ -9,6 +9,7 @@ class ExperienceLikeModel {
         this.collection = db.collection('experience_likes');
         this._db = db;
     }
+
     /**
      * 新增讚至一篇經驗
      * @param {string} experience_id - experience's id
@@ -37,7 +38,41 @@ class ExperienceLikeModel {
         }).then((result) => {
             return result.insertedId;
         }).catch((err) => {
-            if (err.code === 11000) {  //E11000 duplicate key error
+            if (err.code === 11000) { //E11000 duplicate key error
+                throw new DuplicateKeyError("該篇文章已經被按讚");
+            } else {
+                throw err;
+            }
+        });
+    }
+
+    /**
+     * delete like by experience_id and user
+     * @param {string} experience_id - experience id
+     * @param {object} user - user object
+     * @returns {promise}
+     *  - resolve : true/false
+     *  - reject : DuplicateKeyError/Default Error
+     */
+    deleteLike(experience_id, user) {
+        const experience_model = new ExperienceModel(this._db);
+        return experience_model.isExist(experience_id).then((is_exist) => {
+            if (!is_exist) {
+                throw new ObjectNotExistError("該篇文章不存在");
+            }
+
+            return this.collection.deleteOne({
+                experience_id: new ObjectId(experience_id),
+                user: user,
+            });
+        }).then((result) => {
+            if (result.deletedCount == 0) {
+                throw new ObjectNotExistError("此讚不存在");
+            } else {
+                return result.deletedCount == 1;
+            }
+        }).catch((err) => {
+            if (err.code === 11000) { //E11000 duplicate key error
                 throw new DuplicateKeyError("該篇文章已經被按讚");
             } else {
                 throw err;

--- a/models/experience_like_model.js
+++ b/models/experience_like_model.js
@@ -51,7 +51,7 @@ class ExperienceLikeModel {
      * @param {string} experience_id - experience id
      * @param {object} user - user object
      * @returns {promise}
-     *  - resolve : true/false
+     *  - resolve : true
      *  - reject : DuplicateKeyError/Default Error
      */
     deleteLike(experience_id, user) {
@@ -69,13 +69,7 @@ class ExperienceLikeModel {
             if (result.deletedCount == 0) {
                 throw new ObjectNotExistError("此讚不存在");
             } else {
-                return result.deletedCount == 1;
-            }
-        }).catch((err) => {
-            if (err.code === 11000) { //E11000 duplicate key error
-                throw new DuplicateKeyError("該篇文章已經被按讚");
-            } else {
-                throw err;
+                return true;
             }
         });
     }

--- a/models/experience_model.js
+++ b/models/experience_model.js
@@ -170,6 +170,23 @@ class ExperienceModel {
         return this._incrementField(field, id);
     }
 
+    /**
+     * 根據id減少experience的like_count
+     * @param {string} id - experiences of id
+     * @returns {Promise}
+     *  - resolved : {
+     *        value: {
+     *            like_count: Current Like Count (after decrement 1)
+     *        }
+     *    }
+     *
+     *  - reject : ObjectNotExistError/Default Error
+     */
+    decrementLikeCount(id) {
+        const field = "like_count";
+        return this._decrementField(field, id);
+    }
+
     _incrementField(field, id) {
         if (!mongo.ObjectId.isValid(id)) {
             throw new ObjectNotExistError("該文章不存在");
@@ -179,6 +196,31 @@ class ExperienceModel {
             {
                 $inc: {
                     [field]: 1,
+                },
+            },
+            {
+                projection: {
+                    [field]: 1,
+                },
+                returnOriginal: false,
+            }
+        );
+    }
+
+    _decrementField(field, id) {
+        if (!mongo.ObjectId.isValid(id)) {
+            throw new ObjectNotExistError("該文章不存在");
+        }
+
+        return this.collection.findOneAndUpdate({
+            _id: new mongo.ObjectId(id),
+            [field]: {
+                $gt: 0,
+            },
+        },
+            {
+                $inc: {
+                    [field]: -1,
                 },
             },
             {

--- a/routes/experiences/likes.js
+++ b/routes/experiences/likes.js
@@ -57,8 +57,45 @@ router.post('/:id/likes', [
     },
 ]);
 
-router.delete('/:id/likes', function(req, res, next) {
-    res.send('Yo! you are in DELETE /experiences/:id/likes');
-});
+router.delete('/:id/likes', [
+    authentication.cachedFacebookAuthenticationMiddleware,
+    function(req, res, next) {
+        winston.info(req.originalUrl, {
+            ip: req.ip,
+            ips: req.ips,
+        });
+
+        const user = {
+            id: req.user.id,
+            type: req.user.type,
+        };
+        const experience_id = req.params.id;
+        const experience_like_model = new ExperienceLikeModel(req.db);
+        const experience_model = new ExperienceModel(req.db);
+
+        experience_like_model.deleteLike(experience_id, user).then(() => {
+            return experience_model.decrementLikeCount(experience_id);
+        }).then((result) => {
+            res.send({
+                success: true,
+            });
+        }).catch((err) => {
+            winston.info(req.originalUrl, {
+                id: experience_id,
+                ip: req.ip,
+                ips: req.ips,
+                err: err.message,
+            });
+
+            if (err instanceof DuplicateKeyError) {
+                next(new HttpError(err.message, 403));
+            } else if (err instanceof ObjectNotExistError) {
+                next(new HttpError(err.message, 404));
+            } else {
+                next(new HttpError("Internal Server Error", 500));
+            }
+        });
+    },
+]);
 
 module.exports = router;

--- a/routes/experiences/likes.js
+++ b/routes/experiences/likes.js
@@ -66,8 +66,8 @@ router.delete('/:id/likes', [
         });
 
         const user = {
-            id: req.user.id,
-            type: req.user.type,
+            id: req.user.facebook_id,
+            type: 'facebook',
         };
         const experience_id = req.params.id;
         const experience_like_model = new ExperienceLikeModel(req.db);

--- a/test/api/experiences/testLikes.js
+++ b/test/api/experiences/testLikes.js
@@ -1,4 +1,3 @@
-debugger;
 const assert = require('chai').assert;
 const mongo = new require('mongodb');
 const ObjectId = new require('mongodb').ObjectId;

--- a/test/api/experiences/testLikes.js
+++ b/test/api/experiences/testLikes.js
@@ -2,7 +2,10 @@ const assert = require('chai').assert;
 const mongo = new require('mongodb');
 const request = require('supertest');
 const app = require('../../../app');
-const { MongoClient, ObjectId } = require('mongodb');
+const {
+    MongoClient,
+    ObjectId,
+} = require('mongodb');
 const sinon = require('sinon');
 require('sinon-as-promised');
 const config = require('config');
@@ -155,9 +158,9 @@ describe('Experience Likes Test', function() {
                 })
                 .then((res) => {
                     return request(app).post(uri)
-                    .send({
-                        access_token: 'other_fakeaccesstoken',
-                    });
+                        .send({
+                            access_token: 'other_fakeaccesstoken',
+                        });
                 })
                 .then((res) => {
                     return db.collection("experiences")
@@ -184,17 +187,17 @@ describe('Experience Likes Test', function() {
             sandbox.restore();
             let pro1 = db.collection('experience_likes').remove();
             let pro2 = db.collection('experiences').remove({});
-            let pro3 = db.collection('experience_likes').remove({});
-            return Promise.all([pro1, pro2, pro3]);
+            return Promise.all([pro1, pro2]);
         });
 
     });
 
     describe('Delete : /experiences/:id/likes', function() {
-        let experience_id = undefined;
+        let experience_id = null;
+        let test_likes = null;
         let sandbox;
 
-        beforeEach('create user', function() {
+        beforeEach('mock user', function() {
             sandbox = sinon.sandbox.create();
             sandbox.stub(authentication, 'cachedFacebookAuthentication')
                 .withArgs(sinon.match.object, sinon.match.object, 'fakeaccesstoken')
@@ -227,6 +230,8 @@ describe('Experience Likes Test', function() {
                     experience_id: result.insertedId,
 
                 }]);
+            }).then((likes) => {
+                test_likes = likes.ops;
             });
         });
 
@@ -264,7 +269,9 @@ describe('Experience Likes Test', function() {
 
 
         it('should delete the record(but the like is not exist) ,and return 404', function() {
-            return db.collection('experience_likes').remove().then((result) => {
+            return db.collection('experience_likes').remove({
+                user: test_likes[0].user,
+            }).then((result) => {
                 return request(app)
                     .delete('/experiences/' + experience_id + '/likes')
                     .send({

--- a/test/api/experiences/testLikes.js
+++ b/test/api/experiences/testLikes.js
@@ -270,8 +270,23 @@ describe('Experience Likes Test', function() {
             ]);
         });
 
+        it('cannot delete like, beacause the user does not login and return 404', function() {
+            return db.collection('experience_likes').remove({
+                user: test_likes[0].user,
+            }).then((result) => {
+                return request(app)
+                    .delete('/experiences/' + experience_id + '/likes')
+                    .expect(401);
+            }).then((res) => {
+                return db.collection('experiences').findOne({
+                    _id: new ObjectId(experience_id),
+                });
+            }).then((experience) => {
+                assert.equal(experience.like_count, 2, 'the like_count should be 2 (it can not change)');
+            });
+        });
 
-        it('cannot delete like, beacause like does not exist and return 404', function() {
+        it('cannot delete like, beacause the like does not exist and return 404', function() {
             return db.collection('experience_likes').remove({
                 user: test_likes[0].user,
             }).then((result) => {
@@ -290,7 +305,7 @@ describe('Experience Likes Test', function() {
             });
         });
 
-        it('cannot delete like, because experience id does not exist and return 404', function() {
+        it('cannot delete like, because experience does not exist and return 404', function() {
             return db.collection('experience_likes').remove({
                 user: test_likes[0].user,
             }).then((result) => {
@@ -308,7 +323,6 @@ describe('Experience Likes Test', function() {
                 assert.equal(experience.like_count, 2, 'the like_count should be 2 (it can not change)');
             });
         });
-
 
         afterEach(function() {
             sandbox.restore();

--- a/test/api/experiences/testLikes.js
+++ b/test/api/experiences/testLikes.js
@@ -194,21 +194,19 @@ describe('Experience Likes Test', function() {
         let experience_id = undefined;
         let sandbox;
 
-        beforeEach('Create test data', function() {
-
+        beforeEach('create user', function() {
             sandbox = sinon.sandbox.create();
             sandbox.stub(authentication, 'cachedFacebookAuthentication')
-                .withArgs(sinon.match.object, 'fakeaccesstoken')
-                .resolves({
-                    id: '-1',
-                    name: 'markLin',
-                });
+                .withArgs(sinon.match.object, sinon.match.object, 'fakeaccesstoken')
+                .resolves(fake_user);
+
+        });
+
+        beforeEach('create test data', function() {
+
             return db.collection('experiences').insertOne({
                 type: 'interview',
-                author: {
-                    type: "facebook",
-                    _id: "123",
-                },
+                author: fake_user.facebook,
                 status: "published",
                 like_count: 2,
             }).then(function(result) {


### PR DESCRIPTION
#200 

本次修改重點
1. 新增API `Delete /experiences/:id/likes`。
2. 增加api測試。
3. 修改程式碼格式。(測試那的程式碼)