### PR TITLE
當計算出來的 `estimated_hourly_wage` 為 undefined，該欄位不存入ＤＢ

### DIFF
--- a/routes/workings_post.js
+++ b/routes/workings_post.js
@@ -360,7 +360,10 @@ function main(req, res, next) {
             amount: req.custom.salary_amount,
         };
 
-        working.estimated_hourly_wage = helper.calculateEstimatedHourlyWage(working);
+        const wage = helper.calculateEstimatedHourlyWage(working);
+        if(typeof wage !== 'undefined'){
+            working.estimated_hourly_wage = wage;
+        }
     }
     if (working.is_currently_employed === 'no') {
         working.data_time = {

--- a/routes/workings_post.js
+++ b/routes/workings_post.js
@@ -361,7 +361,7 @@ function main(req, res, next) {
         };
 
         const wage = helper.calculateEstimatedHourlyWage(working);
-        if(typeof wage !== 'undefined'){
+        if (typeof wage !== 'undefined') {
             working.estimated_hourly_wage = wage;
         }
     }

--- a/routes/workings_post.js
+++ b/routes/workings_post.js
@@ -360,9 +360,9 @@ function main(req, res, next) {
             amount: req.custom.salary_amount,
         };
 
-        const wage = helper.calculateEstimatedHourlyWage(working);
-        if (typeof wage !== 'undefined') {
-            working.estimated_hourly_wage = wage;
+        const estimated_hourly_wage = helper.calculateEstimatedHourlyWage(working);
+        if (typeof estimated_hourly_wage !== 'undefined') {
+            working.estimated_hourly_wage = estimated_hourly_wage;
         }
     }
     if (working.is_currently_employed === 'no') {

--- a/test/testWorkingsPost.js
+++ b/test/testWorkingsPost.js
@@ -644,6 +644,31 @@ describe('Workings 工時資訊', function() {
                     });
             });
 
+            for(let salary_type of ['month', 'year', 'day']) {
+                it(`doc shouldn't have 'estimated_hourly_wage' field if salary_type is '${salary_type}' 
+                    but no WorkTime information`, function() {
+                    const send_request = request(app).post('/workings')
+                        .send(generateAllPayload({
+                            salary_type: salary_type,
+                            salary_amount: '10000',
+                            week_work_time: -1,
+                            day_real_work_time: -1,
+                            day_promised_work_time: -1,
+                            overtime_frequency: -1,
+                        }))
+                        .expect(200)
+                        .then((res) => {
+                            return res.body.working._id;
+                        });
+                    const test_db = send_request.then((data_id) => {
+                        return db.collection('workings').findOne({_id:ObjectId(data_id)}).then(result => {
+                            assert.notProperty(result, 'estimated_hourly_wage');
+                        });
+                    });
+                    return Promise.all([send_request, test_db]);
+                });
+            }
+
             it('salary_amount is required', function() {
                 return request(app).post('/workings')
                     .send(generateSalaryRelatedPayload({

--- a/test/testWorkingsPost.js
+++ b/test/testWorkingsPost.js
@@ -602,7 +602,7 @@ describe('Workings 工時資訊', function() {
         });
 
         describe('estimated_hourly_wage Part', function() {
-            it(`should have 'estimated_hourly_wage' field, if salary_type is 'hour' `, function() {
+            it(`should have 'estimated_hourly_wage' field, if salary_type is 'hour'`, function() {
                 return request(app).post('/workings')
                     .send(generateSalaryRelatedPayload({
                         salary_type: 'hour',
@@ -675,11 +675,11 @@ describe('Workings 工時資訊', function() {
                             day_promised_work_time: -1,
                             overtime_frequency: -1,
                         }))
-                        .expect(200)
-                        .then((res) => {
-                            return res.body.working._id;
-                        });
-                    const test_db = send_request.then((data_id) => {
+                        .expect(200);
+
+                    const test_db = send_request.then((res) => {
+                        return res.body.working._id;
+                    }).then((data_id) => {
                         return db.collection('workings').findOne({_id: ObjectId(data_id)}).then(result => {
                             assert.notProperty(result, 'estimated_hourly_wage');
                         });
@@ -697,11 +697,11 @@ describe('Workings 工時資訊', function() {
                         salary_amount: -1,
                         experience_in_year: -1,
                     }))
-                    .expect(200)
-                    .then((res) => {
-                        return res.body.working._id;
-                    });
-                const test_db = send_request.then((data_id) => {
+                    .expect(200);
+
+                const test_db = send_request.then((res) => {
+                    return res.body.working._id;
+                }).then((data_id) => {
                     return db.collection('workings').findOne({_id: ObjectId(data_id)}).then(result => {
                         assert.notProperty(result, 'estimated_hourly_wage');
                     });

--- a/test/testWorkingsPost.js
+++ b/test/testWorkingsPost.js
@@ -644,7 +644,7 @@ describe('Workings 工時資訊', function() {
                     });
             });
 
-            for(let salary_type of ['month', 'year', 'day']) {
+            for (let salary_type of ['month', 'year', 'day']) {
                 it(`doc shouldn't have 'estimated_hourly_wage' field if salary_type is '${salary_type}' 
                     but no WorkTime information`, function() {
                     const send_request = request(app).post('/workings')
@@ -661,7 +661,7 @@ describe('Workings 工時資訊', function() {
                             return res.body.working._id;
                         });
                     const test_db = send_request.then((data_id) => {
-                        return db.collection('workings').findOne({_id:ObjectId(data_id)}).then(result => {
+                        return db.collection('workings').findOne({_id: ObjectId(data_id)}).then(result => {
                             assert.notProperty(result, 'estimated_hourly_wage');
                         });
                     });


### PR DESCRIPTION
- [x] 當計算出來的估計時薪為undefined，就不要塞進working 物件的欄位
- [x] 加上測試

其中，測試的部分，不能去測打完POST的response，因為它並不是真的ＤＢ裡面的資料。


ref: #322 