### PR TITLE
If coveralls fail, don't affect the ci status

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,9 @@ jobs:
             - run:
                 name: Unit test and API test
                 command: npm test -- --timeout 30s
-            - run: npm run coveralls
+            - run:
+                name: Coveralls
+                command: npm run coveralls || /bin/true
             - run:
                 name: Lint
                 command: npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,5 @@ install:
 
 script:
     - npm test -- --timeout 30s
-    - npm run coveralls
+    - npm run coveralls || /bin/true
     - npm run lint


### PR DESCRIPTION
對於 fork 出去的專案，可能沒有 coveralls 的服務，所以讓它在 CI 裡是可選的