### PR TITLE
DELETE /experiences/:id/likes 補測試

### DIFF
--- a/test/api/experiences/testLikes.js
+++ b/test/api/experiences/testLikes.js
@@ -11,11 +11,14 @@ require('sinon-as-promised');
 const config = require('config');
 
 const authentication = require('../../../libs/authentication');
+const {
+    generateInterviewExperienceData,
+} = require('../testData');
 
 describe('Experience Likes Test', function() {
 
     let db = undefined;
-    let fake_user = {
+    const fake_user = {
         _id: new ObjectId(),
         facebook_id: '-1',
         facebook: {
@@ -23,7 +26,7 @@ describe('Experience Likes Test', function() {
             name: 'markLin',
         },
     };
-    let fake_other_user = {
+    const fake_other_user = {
         _id: new ObjectId(),
         facebook_id: '-2',
         facebook: {
@@ -193,45 +196,71 @@ describe('Experience Likes Test', function() {
     });
 
     describe('Delete : /experiences/:id/likes', function() {
-        let experience_id = null;
+        let experience_id_string_by_user = null;
+        let experience_id_by_user = null;
+        let experience_id_by_other_user = null;
         let test_likes = null;
         let sandbox;
 
         beforeEach('mock user', function() {
             sandbox = sinon.sandbox.create();
-            sandbox.stub(authentication, 'cachedFacebookAuthentication')
+            const cachedFacebookAuthentication = sandbox.stub(authentication, 'cachedFacebookAuthentication');
+
+            cachedFacebookAuthentication
                 .withArgs(sinon.match.object, sinon.match.object, 'fakeaccesstoken')
                 .resolves(fake_user);
+            cachedFacebookAuthentication
+                .withArgs(sinon.match.object, sinon.match.object, 'otherFakeAccessToken')
+                .resolves(fake_other_user);
 
         });
 
         beforeEach('create test data', function() {
-
-            return db.collection('experiences').insertOne({
-                type: 'interview',
-                author: {
+            const experience_user = Object.assign(generateInterviewExperienceData(), {
+                author_id: {
                     id: fake_user.facebook_id,
                     type: 'facebook',
                 },
-                status: "published",
                 like_count: 2,
-            }).then(function(result) {
-                experience_id = result.insertedId.toString();
+            });
+
+            const experience_other_user = Object.assign(generateInterviewExperienceData(), {
+                author: {
+                    id: fake_other_user.facebook_id,
+                    type: 'facebook',
+                },
+            });
+
+            return db.collection('experiences').insertMany([
+                experience_user,
+                experience_other_user,
+            ]).then(function(result) {
+                experience_id_by_user = result.ops[0]._id;
+                experience_id_string_by_user = result.ops[0]._id.toString();
+                experience_id_by_other_user = result.ops[1]._id;
+
                 return db.collection('experience_likes').insertMany([{
                     created_at: new Date(),
                     user: {
                         id: fake_user.facebook_id,
                         type: 'facebook',
                     },
-                    experience_id: result.insertedId,
+                    experience_id: experience_id_by_user,
                 }, {
                     created_at: new Date(),
                     user: {
-                        id: '-2',
+                        id: fake_other_user.facebook_id,
                         type: 'facebook',
                     },
-                    experience_id: result.insertedId,
+                    experience_id: experience_id_by_user,
 
+                }, {
+                    created_at: new Date(),
+                    user: {
+                        id: fake_user.facebook_id,
+                        type: 'facebook',
+                    },
+                    experience_id: experience_id_by_other_user,
                 }]);
             }).then((likes) => {
                 test_likes = likes.ops;
@@ -240,7 +269,7 @@ describe('Experience Likes Test', function() {
 
         it('should delete the record, and return success', function() {
             const req = request(app)
-                .delete('/experiences/' + experience_id + '/likes')
+                .delete(`/experiences/${experience_id_string_by_user}/likes`)
                 .send({
                     access_token: 'fakeaccesstoken',
                 })
@@ -249,7 +278,7 @@ describe('Experience Likes Test', function() {
             return Promise.all([
                 req.then((res) => {
                     return db.collection('experience_likes').findOne({
-                        experience_id: new ObjectId(experience_id),
+                        experience_id: experience_id_by_user,
                         user: {
                             id: fake_user.facebook_id,
                             type: 'facebook',
@@ -261,7 +290,7 @@ describe('Experience Likes Test', function() {
                 }),
                 req.then((res) => {
                     return db.collection('experiences').findOne({
-                        _id: new ObjectId(experience_id),
+                        _id: experience_id_by_user,
                     });
                 })
                 .then((experience) => {
@@ -275,11 +304,11 @@ describe('Experience Likes Test', function() {
                 user: test_likes[0].user,
             }).then((result) => {
                 return request(app)
-                    .delete('/experiences/' + experience_id + '/likes')
+                    .delete(`/experiences/${experience_id_string_by_user}/likes`)
                     .expect(401);
             }).then((res) => {
                 return db.collection('experiences').findOne({
-                    _id: new ObjectId(experience_id),
+                    _id: experience_id_by_user,
                 });
             }).then((experience) => {
                 assert.equal(experience.like_count, 2, 'the like_count should be 2 (it can not change)');
@@ -291,14 +320,14 @@ describe('Experience Likes Test', function() {
                 user: test_likes[0].user,
             }).then((result) => {
                 return request(app)
-                    .delete('/experiences/' + experience_id + '/likes')
+                    .delete(`/experiences/${experience_id_string_by_user}/likes`)
                     .send({
                         access_token: 'fakeaccesstoken',
                     })
                     .expect(404);
             }).then((res) => {
                 return db.collection('experiences').findOne({
-                    _id: new ObjectId(experience_id),
+                    _id: experience_id_by_user,
                 });
             }).then((experience) => {
                 assert.equal(experience.like_count, 2, 'the like_count should be 2 (it can not change)');
@@ -317,17 +346,71 @@ describe('Experience Likes Test', function() {
                     .expect(404);
             }).then((res) => {
                 return db.collection('experiences').findOne({
-                    _id: new ObjectId(experience_id),
+                    _id: experience_id_by_user,
                 });
             }).then((experience) => {
                 assert.equal(experience.like_count, 2, 'the like_count should be 2 (it can not change)');
             });
         });
 
+        it('should not delete the other user of like when both user and other user likes the experience_by_user and user delete the like', function() {
+            const req = request(app)
+                .delete(`/experiences/${experience_id_string_by_user}/likes`)
+                .send({
+                    access_token: 'fakeaccesstoken',
+                })
+                .expect(200);
+
+            const check_experience_likes = req
+                .then(() => {
+                    return db.collection('experience_likes').findOne({
+                        experience_id: experience_id_by_user,
+                        user: {
+                            id: fake_other_user.facebook_id,
+                            type: 'facebook',
+                        },
+                    });
+                })
+                .then((result) => {
+                    assert.equal(result.user.id, fake_other_user.facebook_id, 'the userB of like should exist');
+                });
+
+            return Promise.all([
+                check_experience_likes,
+            ]);
+        });
+
+        it('should not delete the experience_by_other_user of user like  when the user likes both experience_by_user and experience_by_other_user, and user delete the experience_by_user of like', function() {
+            const req = request(app)
+                .delete(`/experiences/${experience_id_string_by_user}/likes`)
+                .send({
+                    access_token: 'fakeaccesstoken',
+                })
+                .expect(200);
+
+            const check_experience_likes = req
+                .then(() => {
+                    return db.collection('experience_likes').findOne({
+                        experience_id: experience_id_by_other_user,
+                        user: {
+                            id: fake_user.facebook_id,
+                            type: 'facebook',
+                        },
+                    });
+                })
+                .then((result) => {
+                    assert.equal(result.user.id, fake_user.facebook_id, 'the experience_by_other_user of user like should exist');
+                });
+
+            return Promise.all([
+                check_experience_likes,
+            ]);
+        });
+
         afterEach(function() {
             sandbox.restore();
-            let pro1 = db.collection('experience_likes').remove();
-            let pro2 = db.collection('experiences').remove({});
+            const pro1 = db.collection('experience_likes').remove();
+            const pro2 = db.collection('experiences').remove({});
             return Promise.all([pro1, pro2]);
         });
     });

--- a/test/api/experiences/testLikes.js
+++ b/test/api/experiences/testLikes.js
@@ -217,7 +217,7 @@ describe('Experience Likes Test', function() {
 
         beforeEach('create test data', function() {
             const experience_by_user = Object.assign(generateInterviewExperienceData(), {
-                author_id: {
+                author: {
                     id: fake_user.facebook_id,
                     type: 'facebook',
                 },

--- a/test/api/experiences/testLikes.js
+++ b/test/api/experiences/testLikes.js
@@ -353,7 +353,7 @@ describe('Experience Likes Test', function() {
             });
         });
 
-        it('should not delete the other user of like when both user and other user likes the experience_by_user and user delete the like', function() {
+        it('should not delete others`s like if user cancels the like of an experience', function() {
             const req = request(app)
                 .delete(`/experiences/${experience_id_string_by_user}/likes`)
                 .send({
@@ -380,7 +380,7 @@ describe('Experience Likes Test', function() {
             ]);
         });
 
-        it('should not delete the experience_by_other_user of user like  when the user likes both experience_by_user and experience_by_other_user, and user delete the experience_by_user of like', function() {
+        it('should not delete the other experiences`s like, when the user cancels the like of an experience', function() {
             const req = request(app)
                 .delete(`/experiences/${experience_id_string_by_user}/likes`)
                 .send({
@@ -399,7 +399,7 @@ describe('Experience Likes Test', function() {
                     });
                 })
                 .then((result) => {
-                    assert.equal(result.user.id, fake_user.facebook_id, 'the experience_by_other_user of user like should exist');
+                    assert.equal(result.user.id, fake_user.facebook_id, 'the other experience`s like should exist');
                 });
 
             return Promise.all([

--- a/test/api/experiences/testLikes.js
+++ b/test/api/experiences/testLikes.js
@@ -216,7 +216,7 @@ describe('Experience Likes Test', function() {
         });
 
         beforeEach('create test data', function() {
-            const experience_user = Object.assign(generateInterviewExperienceData(), {
+            const experience_by_user = Object.assign(generateInterviewExperienceData(), {
                 author_id: {
                     id: fake_user.facebook_id,
                     type: 'facebook',
@@ -224,7 +224,7 @@ describe('Experience Likes Test', function() {
                 like_count: 2,
             });
 
-            const experience_other_user = Object.assign(generateInterviewExperienceData(), {
+            const experience_by_other_user = Object.assign(generateInterviewExperienceData(), {
                 author: {
                     id: fake_other_user.facebook_id,
                     type: 'facebook',
@@ -232,8 +232,8 @@ describe('Experience Likes Test', function() {
             });
 
             return db.collection('experiences').insertMany([
-                experience_user,
-                experience_other_user,
+                experience_by_user,
+                experience_by_other_user,
             ]).then(function(result) {
                 experience_id_by_user = result.ops[0]._id;
                 experience_id_string_by_user = result.ops[0]._id.toString();

--- a/test/api/experiences/testLikes.js
+++ b/test/api/experiences/testLikes.js
@@ -372,7 +372,7 @@ describe('Experience Likes Test', function() {
                     });
                 })
                 .then((result) => {
-                    assert.equal(result.user.id, fake_other_user.facebook_id, 'the userB of like should exist');
+                    assert.equal(result.user.id, fake_other_user.facebook_id, 'the other user of like should exist');
                 });
 
             return Promise.all([


### PR DESCRIPTION
#313

本次修改重點
1. 新增以下兩個案例測試
* A & B 都按了 X讚， B刪對Ｘ的讚的時候，不能刪到Ａ對Ｘ的讚
* A按了X, Y 讚，Ａ 對Ｘ刪讚的時候，不能刪到Ａ對Ｙ的讚
2. 有些不會變動的變數將let修改為const
3. 將`'/experiences/' + experience_id + '/likes'`這種類形的修改為``/experiences/${experience_id_string_by_user}/likes``