### PR TITLE
[migration] 移除 estimated_hourly_wage 欄位，當該欄位為null 

### DIFF
--- a/database/migrations/index.js
+++ b/database/migrations/index.js
@@ -5,4 +5,5 @@ module.exports = [
     'create-workings-collection',
     'migration-2017-04-28-create-users-collection',
     'migration-2017-04-28-migrate-authors-to-users',
+    'migration-2017-05-26-remove-null-estimated_hourly_wage-fields',
 ];

--- a/database/migrations/migration-2017-05-26-remove-null-estimated_hourly_wage-fields.js
+++ b/database/migrations/migration-2017-05-26-remove-null-estimated_hourly_wage-fields.js
@@ -1,0 +1,12 @@
+module.exports = (db) => {
+    return db.collection('workings').updateMany({
+        estimated_hourly_wage: {
+            $exists: true,
+            $eq: null,
+        }
+    }, {
+        $unset: {
+            estimated_hourly_wage: '',
+        }
+    });
+};


### PR DESCRIPTION
to fix #331 

更新`workings` collection裡面，所有 `estimated_hourly_wage` 欄位存在且為`null`的資料，將 `estimated_hourly_wage` 欄位移除。

我用mongo cli 手動測試沒問題，但不太確定migration要如何做測試？
