### PR TITLE
remove dont know option from work experiences

### DIFF
--- a/routes/work_experiences/index.js
+++ b/routes/work_experiences/index.js
@@ -203,8 +203,8 @@ function validateWorkInputFields(data) {
     }
 
     if (data.recommend_to_others) {
-        if (!shouldIn(data.recommend_to_others, ["yes", "no", "don\'t know"])) {
-            throw new HttpError('是否推薦此工作需為 yes/no/don\'t know', 422);
+        if (!shouldIn(data.recommend_to_others, ["yes", "no"])) {
+            throw new HttpError("是否推薦此工作需為 yes or no", 422);
         }
     }
 }

--- a/test/api/work_experiences/testWorkExperiences.js
+++ b/test/api/work_experiences/testWorkExperiences.js
@@ -377,10 +377,10 @@ describe('experiences 面試和工作經驗資訊', function() {
                     .expect(422);
             });
 
-            it('recommend_to_others should be ["yes", "no", "don\'t know"]', function() {
+            it('recommend_to_others should be ["yes", "no"]', function() {
                 return request(app).post('/work_experiences')
                     .send(generateWorkExperiencePayload({
-                        recommend_to_others: "yeah",
+                        recommend_to_others: "don't know",
                     }))
                     .expect(422);
             });


### PR DESCRIPTION
wendellliu [6:57 PM] 
想討論一個小地方
工作經驗表單中有一個項目是「會推薦給其他人嗎？」

這個是非必填，但又有個  *難說喔（don’t know）*
我自己是覺得蠻多餘的，我覺得選填的決定是好的，但是不是就把這個中性選項拿掉
（感覺上選項是可以侵略性一點，但可以不答） (edited)

mark86092 [8:36 PM] 
我想想當初放的理由


----- June 2nd -----
mark86092 [2:00 PM] 
@wendellliu 我今天回去回答你這個問題

wendellliu [2:00 PM] 
好的！

barry800414 [4:18 PM] 
原本這個欄位是像面試滿意度那樣，給一到五分。後來討論覺得這樣的資訊對使用者來說不好理解，不如直接 是/否推薦此工作，後來才加上[難說喔]這個選項，讓不想選是或否的人有得選。
所以說起來，應該是有幾種選項：
1. 必填，有[難說喔]這個中性選項。
2. 選填，沒有[難說喔]這個中性選項。但這樣的缺點是，使用者不小心點到是或否，無法取消。
3. 選填，有[難說喔]這個中性選項。雖然會覺得[難說喔]有點雞肋，但其實跟沒填的語意差不多，不影響使用者使用。（目前的選項） (edited)

[4:19] 
其實我是覺得可以改成 1. 必填

[4:20] 
@tin 這邊想問一下設計上是否有什麼考量？ (edited)

mark86092 [4:24 PM] 
後端的翻譯是用：難說喔 = 我不知道

tin [6:26 PM] 
嗯嗯嗯 覺得晏成說得沒錯。
我傾向一樣是非必填，但把那個選項拿掉。

[6:26] 
@barry800414 再點一下選項會取消
（跟現在首頁加班有無加班費使用情境一樣） (edited)

mark86092 [6:28 PM] 
我也覺得選填比較好，這樣三種情況（是，否，空）比較切得清楚

barry800414 [7:47 PM] 
OK，那我修改spec，以及開後端的issue，前端再麻煩你們修改了

tin [9:26 PM] 
@wendellliu 結論：
非必填，但把 *難說喔* 拿掉
謝謝！ (edited)


wendellliu [9:28 PM] 
好的，感謝！