### PR TITLE
測試 POST 的 API 是否可以透過 Authorization Header 認證

### DIFF
--- a/middlewares/authentication.js
+++ b/middlewares/authentication.js
@@ -3,18 +3,7 @@ const HttpError = require('../libs/errors').HttpError;
 
 function cachedFacebookAuthenticationMiddleware(req, res, next) {
     const db = req.redis_client;
-    let access_token;
-    // POST or GET
-    if (req.headers && req.headers.authorization) {
-        const parts = req.headers.authorization.split(' ');
-        if (parts.length === 2 && parts[0] === 'Bearer') {
-            access_token = parts[1];
-        }
-    } else if (req.body.access_token !== undefined) {
-        access_token = req.body.access_token;
-    } else {
-        access_token = req.query.access_token;
-    }
+    const access_token = _getAccessToken(req);
 
     if (typeof access_token !== "string") {
         next(new HttpError('Unauthorized', 401));
@@ -29,6 +18,27 @@ function cachedFacebookAuthenticationMiddleware(req, res, next) {
                 next(new HttpError('Unauthorized', 401));
             });
     }
+}
+
+/**
+ * _getAccessToken
+ * Getting acceess token from body or header
+ * @param req - http request
+ * @returns {string} - access token
+ */
+function _getAccessToken(req) {
+    let access_token;
+    if (req.headers && req.headers.authorization) {
+        const parts = req.headers.authorization.split(' ');
+        if (parts.length === 2 && parts[0] === 'Bearer') {
+            access_token = parts[1];
+        }
+    } else if (req.body.access_token !== undefined) {
+        access_token = req.body.access_token;
+    } else {
+        access_token = req.query.access_token;
+    }
+    return access_token;
 }
 
 module.exports = {

--- a/test/testMiddlewares.js
+++ b/test/testMiddlewares.js
@@ -34,12 +34,40 @@ describe('Authentication Middleware', function() {
             sandbox = sinon.sandbox.create();
         });
 
-        it('get property user if success', function(done) {
+        it('get property user if success ( body token )', function(done) {
             const req = {
                 redis_client: {},
                 body: {
                     access_token: "random",
                 },
+            };
+
+            const fake_user = {
+                _id: new ObjectId(),
+                facebook_id: '-1',
+            };
+
+            const stub = sandbox.stub(authenticationLib, 'cachedFacebookAuthentication').resolves(fake_user);
+
+            authentication.cachedFacebookAuthenticationMiddleware(req, {}, function(err) {
+                try {
+                    assert.isUndefined(err);
+                    assert.property(req, 'user');
+                    assert.deepEqual(req.user, fake_user);
+                    sinon.assert.calledOnce(stub);
+                    done();
+                } catch (e) {
+                    done(e);
+                }
+            });
+        });
+
+        it('get property user if success ( header authorization token )', function(done) {
+            const req = {
+                headers: {
+                    authorization: "Bearer mF_9.B5f-4.1JqM",
+                },
+                redis_client: {},
             };
 
             const fake_user = {

--- a/test/testMiddlewares.js
+++ b/test/testMiddlewares.js
@@ -63,11 +63,14 @@ describe('Authentication Middleware', function() {
         });
 
         it('get property user if success ( header authorization token )', function(done) {
+            const bearer_token = "Bearer mF_9.B5f-4.1JqM";
+            const access_token = "mF_9.B5f-4.1JqM";
             const req = {
                 headers: {
-                    authorization: "Bearer mF_9.B5f-4.1JqM",
+                    authorization: bearer_token,
                 },
                 redis_client: {},
+                db: {},
             };
 
             const fake_user = {
@@ -75,7 +78,9 @@ describe('Authentication Middleware', function() {
                 facebook_id: '-1',
             };
 
-            const stub = sandbox.stub(authenticationLib, 'cachedFacebookAuthentication').resolves(fake_user);
+            const stub = sandbox.stub(authenticationLib, 'cachedFacebookAuthentication')
+                .withArgs(sinon.match.object, sinon.match.object, access_token)
+                .resolves(fake_user);
 
             authentication.cachedFacebookAuthenticationMiddleware(req, {}, function(err) {
                 try {


### PR DESCRIPTION
#300 
本次修改重點

1. 新增 header authorization token 認證測試。
2. 簡單的重構`cachedFacebookAuthenticationMiddleware `。

我這邊說一下為啥要將access_token拉出來成一個function，主要有三個原因。
1. 增加`cachedFacebookAuthenticationMiddleware `可閱讀性。
2. 增加可測試性，我們有`_getAccessToken`，就可以只針對這個進行`body`、`header`、`get`這三種進行測試。
3. 在重構領域中，在程式碼內可以寫注解的，事實上就代表可以拉出成一個`function`了。