### PR TITLE
使用者搜尋時，後端會將搜尋關鍵字儲存

### DIFF
--- a/database/migrations/create-companyKeywords-collection.js
+++ b/database/migrations/create-companyKeywords-collection.js
@@ -1,11 +1,11 @@
 module.exports = (db) => {
-    return db.createCollection("search_by_company_keywords", {
+    return db.createCollection("company_keywords", {
         capped: true,
         size: 300000,
         max: 1000,
     })
     .then(() => {
-        return db.collection('search_by_company_keywords').createIndex({
+        return db.collection('company_keywords').createIndex({
             word: 1,
         });
     });

--- a/database/migrations/create-companyKeywords-collection.js
+++ b/database/migrations/create-companyKeywords-collection.js
@@ -1,0 +1,12 @@
+module.exports = (db) => {
+    return db.createCollection("search_by_company_keywords", {
+        capped: true,
+        size: 300000,
+        max: 1000,
+    })
+    .then(() => {
+        return db.collection('search_by_company_keywords').createIndex({
+            word: 1,
+        });
+    });
+};

--- a/database/migrations/create-companyKeywords-collection.js
+++ b/database/migrations/create-companyKeywords-collection.js
@@ -1,8 +1,8 @@
 module.exports = (db) => {
     return db.createCollection("company_keywords", {
         capped: true,
-        size: 300000,
-        max: 1000,
+        size: 6000000,
+        max: 5000,
     })
     .then(() => {
         return db.collection('company_keywords').createIndex({

--- a/database/migrations/create-jobTitleKeywords-collection.js
+++ b/database/migrations/create-jobTitleKeywords-collection.js
@@ -1,0 +1,12 @@
+module.exports = (db) => {
+    return db.createCollection("search_by_job_title_keywords", {
+        capped: true,
+        size: 300000,
+        max: 1000,
+    })
+    .then(() => {
+        return db.collection('search_by_job_title_keywords').createIndex({
+            word: 1,
+        });
+    });
+};

--- a/database/migrations/create-jobTitleKeywords-collection.js
+++ b/database/migrations/create-jobTitleKeywords-collection.js
@@ -1,8 +1,8 @@
 module.exports = (db) => {
     return db.createCollection("job_title_keywords", {
         capped: true,
-        size: 300000,
-        max: 1000,
+        size: 6000000,
+        max: 5000,
     })
     .then(() => {
         return db.collection('job_title_keywords').createIndex({

--- a/database/migrations/create-jobTitleKeywords-collection.js
+++ b/database/migrations/create-jobTitleKeywords-collection.js
@@ -1,11 +1,11 @@
 module.exports = (db) => {
-    return db.createCollection("search_by_job_title_keywords", {
+    return db.createCollection("job_title_keywords", {
         capped: true,
         size: 300000,
         max: 1000,
     })
     .then(() => {
-        return db.collection('search_by_job_title_keywords').createIndex({
+        return db.collection('job_title_keywords').createIndex({
             word: 1,
         });
     });

--- a/database/migrations/index.js
+++ b/database/migrations/index.js
@@ -12,4 +12,6 @@ module.exports = [
     'create-experienceLikes-collection',
     'create-replyLikes-collection',
     'migration-2017-05-09-create-replies-collection',
+    'create-companyKeywords-collection',
+    'create-jobTitleKeywords-collection',
 ];

--- a/models/company_keywords_model.js
+++ b/models/company_keywords_model.js
@@ -5,7 +5,7 @@ class CompanyKeywordModel {
         this.collection = db.collection('company_keywords');
     }
     createKeyword(word) {
-        return this.collection.insertOne({word});
+        return this.collection.insertOne({ word });
     }
 }
 

--- a/models/company_keywords_model.js
+++ b/models/company_keywords_model.js
@@ -1,12 +1,12 @@
 
-class CompanyKeyWordsModel {
+class CompanyKeywordModel {
 
     constructor(db) {
-        this.collection = db.collection('search_by_company_keywords');
+        this.collection = db.collection('company_keywords');
     }
     createKeyword(word) {
-        return this.collection.insert({word});
+        return this.collection.insertOne({word});
     }
 }
 
-module.exports = CompanyKeyWordsModel;
+module.exports = CompanyKeywordModel;

--- a/models/company_keywords_model.js
+++ b/models/company_keywords_model.js
@@ -1,0 +1,12 @@
+
+class CompanyKeyWordsModel {
+
+    constructor(db) {
+        this.collection = db.collection('search_by_company_keywords');
+    }
+    createKeyword(word) {
+        return this.collection.insert({word});
+    }
+}
+
+module.exports = CompanyKeyWordsModel;

--- a/models/job_title_keywords_model.js
+++ b/models/job_title_keywords_model.js
@@ -5,7 +5,7 @@ class JobTitleKeyWordModel {
         this.collection = db.collection('job_title_keywords');
     }
     createKeyword(word) {
-        return this.collection.insertOne({word});
+        return this.collection.insertOne({ word });
     }
 }
 

--- a/models/job_title_keywords_model.js
+++ b/models/job_title_keywords_model.js
@@ -1,0 +1,12 @@
+
+class JobTitleKeyWordsModel {
+
+    constructor(db) {
+        this.collection = db.collection('search_by_job_title_keywords');
+    }
+    createKeyword(word) {
+        return this.collection.insert({word});
+    }
+}
+
+module.exports = JobTitleKeyWordsModel;

--- a/models/job_title_keywords_model.js
+++ b/models/job_title_keywords_model.js
@@ -1,12 +1,12 @@
 
-class JobTitleKeyWordsModel {
+class JobTitleKeyWordModel {
 
     constructor(db) {
-        this.collection = db.collection('search_by_job_title_keywords');
+        this.collection = db.collection('job_title_keywords');
     }
     createKeyword(word) {
-        return this.collection.insert({word});
+        return this.collection.insertOne({word});
     }
 }
 
-module.exports = JobTitleKeyWordsModel;
+module.exports = JobTitleKeyWordModel;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec --recursive ",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "lint": "eslint *.js libs/ routes/ test/ middlewares/ models/",
+    "lint:fix": "npm run lint -- --fix",
     "migrate": "node ./bin/migrate"
   },
   "repository": {

--- a/routes/companies/index.js
+++ b/routes/companies/index.js
@@ -24,23 +24,23 @@ function _generateGetCompanyViewModel(companies) {
  * @apiParam {Number} [page=0]
  * @apiSuccess {Object[]} . Companies
  */
-router.get('/search', function (req, res, next) {
+router.get('/search', (req, res, next) => {
     winston.info("/workings/search", { query: req.query, ip: req.ip, ips: req.ips });
 
     const search = req.query.key || "";
     const page = req.query.page || 0;
-    let query;
 
     if (search === "") {
-        throw new HttpError("key is required", 422);
-    } else {
-        query = {
-            $or: [
+        next(new HttpError("key is required", 422));
+        return;
+    }
+
+    const query = {
+        $or: [
                 { name: new RegExp(`^${lodash.escapeRegExp(search.toUpperCase())}`) },
                 { id: search },
-            ],
-        };
-    }
+        ],
+    };
 
     const sort_by = {
         capital: -1,

--- a/routes/companies/index.js
+++ b/routes/companies/index.js
@@ -1,10 +1,20 @@
 const express = require('express');
+
 const router = express.Router();
 const HttpError = require('../../libs/errors').HttpError;
 const lodash = require('lodash');
 const winston = require('winston');
 const CompanyModel = require('../../models/company_model');
 const getCompanyName = require('../company_helper').getCompanyName;
+
+function _generateGetCompanyViewModel(companies) {
+    const result = companies.map((company) => ({
+        id: company.id,
+        name: getCompanyName(company.name),
+        capital: company.capital,
+    }));
+    return result;
+}
 
 /**
  * @api {get} /companies/search Search Company
@@ -14,20 +24,20 @@ const getCompanyName = require('../company_helper').getCompanyName;
  * @apiParam {Number} [page=0]
  * @apiSuccess {Object[]} . Companies
  */
-router.get('/search', function(req, res, next) {
-    winston.info("/workings/search", {query: req.query, ip: req.ip, ips: req.ips});
+router.get('/search', function (req, res, next) {
+    winston.info("/workings/search", { query: req.query, ip: req.ip, ips: req.ips });
 
     const search = req.query.key || "";
     const page = req.query.page || 0;
     let query;
 
-    if (search == "") {
+    if (search === "") {
         throw new HttpError("key is required", 422);
     } else {
         query = {
             $or: [
-                {name: new RegExp("^" + lodash.escapeRegExp(search.toUpperCase()))},
-                {id: search},
+                { name: new RegExp(`^${lodash.escapeRegExp(search.toUpperCase())}`) },
+                { id: search },
             ],
         };
     }
@@ -49,17 +59,6 @@ router.get('/search', function(req, res, next) {
         next(new HttpError("Internal Server Error", 500));
     });
 });
-
-function _generateGetCompanyViewModel(companies) {
-    const result = companies.map((company) => {
-        return {
-            id: company.id,
-            name: getCompanyName(company.name),
-            capital: company.capital,
-        };
-    });
-    return result;
-}
 
 module.exports = router;
 

--- a/routes/experiences/index.js
+++ b/routes/experiences/index.js
@@ -95,6 +95,24 @@ function _generateGetExperiencesViewModel(experiences, total) {
     return result;
 }
 
+function _keyWordFactory(type) {
+    /* eslint-disable global-require */
+    if (type === 'company') {
+        return require('../../models/company_keywords_model');
+    } else if (type === 'job_title') {
+        return require('../../models/job_title_keywords_model');
+    }
+    /* eslint-enale global-require */
+}
+
+function _saveKeyWord(query, type, db) {
+    if (!query) {
+        return;
+    }
+
+    const keyword_model = new (_keyWordFactory(type))(db);
+    keyword_model.createKeyword(query);
+}
 
 /* eslint-disable */
 /**
@@ -164,6 +182,7 @@ router.get('/', wrap(async (req, res) => {
     }
 
     const query = _queryToDBQuery(search_query, search_by, type);
+    _saveKeyWord(search_query, search_by, req.db);
 
     const db_sort_field = (sort_field === 'popularity') ? 'like_count' : sort_field;
     const sort = {

--- a/routes/experiences/index.js
+++ b/routes/experiences/index.js
@@ -111,7 +111,7 @@ function _saveKeyWord(query, type, db) {
     }
 
     const keyword_model = new (_keyWordFactory(type))(db);
-    keyword_model.createKeyword(query);
+    return keyword_model.createKeyword(query);
 }
 
 /* eslint-disable */

--- a/test/api/company_keywords/testCompanyKeywords.js
+++ b/test/api/company_keywords/testCompanyKeywords.js
@@ -8,18 +8,18 @@ const app = require('../../../app');
 const config = require('config');
 const create_capped_collection = require('../../../database/migrations/create-companyKeywords-collection');
 
-describe('Company Keywords Test', function() {
+describe('Company Keywords Test', function () {
     let db = null;
 
-    before(function() {
-        return MongoClient.connect(config.get('MONGODB_URI')).then(function(_db) {
+    before(function () {
+        return MongoClient.connect(config.get('MONGODB_URI')).then(function (_db) {
             db = _db;
         });
     });
 
 
-    describe('Collection company_keywords', function() {
-        it('should return true, if the collection is capped', function() {
+    describe('Collection company_keywords', function () {
+        it('should return true, if the collection is capped', function () {
             return db.collection('company_keywords').isCapped()
                 .then((result) => {
                     assert.isTrue(result);
@@ -27,8 +27,8 @@ describe('Company Keywords Test', function() {
         });
     });
 
-    describe('Get : /experiences (key word check)', function() {
-        it('should return 200', function() {
+    describe('Get : /experiences (key word check)', function () {
+        it('should return 200', function () {
             const query = (new ObjectId()).toString();
             return request(app).get('/experiences')
                 .query({
@@ -36,19 +36,17 @@ describe('Company Keywords Test', function() {
                     search_by: 'company',
                 })
                 .expect(200)
-                .then(() => {
-                    return db.collection('company_keywords')
+                .then(() => db.collection('company_keywords')
                         .findOne({
                             word: query,
-                        });
-                })
+                        }))
                 .then((result) => {
                     assert.equal(result.word, query.toString());
                 });
         });
     });
 
-    after(function() {
+    after(function () {
         return db.collection('company_keywords').drop()
             .then(() => create_capped_collection(db));
     });

--- a/test/api/company_keywords/testCompanyKeywords.js
+++ b/test/api/company_keywords/testCompanyKeywords.js
@@ -1,0 +1,64 @@
+const assert = require('chai').assert;
+const {
+    MongoClient,
+    ObjectId,
+} = require('mongodb');
+const request = require('supertest');
+const app = require('../../../app');
+const config = require('config');
+const create_capped_collection = require('../../../database/migrations/create-companyKeywords-collection');
+
+describe('Company Keywords Test', function() {
+    let db = null;
+
+    before(function() {
+        return MongoClient.connect(config.get('MONGODB_URI')).then(function(_db) {
+            db = _db;
+            return db.collections();
+        }).then((result) => {
+            const target_collection = result.find((collection) => {
+                if (collection.collectionName == "search_by_company_keywords'") {
+                    return collection;
+                }
+            });
+            if (!target_collection) {
+                return create_capped_collection(db);
+            }
+        });
+    });
+
+
+    describe('Get : /company_keywords', function() {
+        it('should return true, if the collection is capped', function() {
+            return db.collection('search_by_company_keywords').isCapped()
+                .then((result) => {
+                    assert.isTrue(result);
+                });
+        });
+    });
+
+    describe('Get : /experiences (key word check)', function() {
+        it('should return 200', function() {
+            const query = new ObjectId();
+            return request(app).get('/experiences')
+                .query({
+                    search_query: query.toString(),
+                    search_by: "company",
+                })
+                .expect(200)
+                .then(() => {
+                    return db.collection('search_by_company_keywords')
+                        .find({
+                            word: query.toString(),
+                        }).toArray();
+                })
+                .then((result) => {
+                    assert.equal(result[0].word, query.toString());
+                });
+        });
+    });
+
+    after(function() {
+        return db.collection('search_by_company_keywords').drop();
+    });
+});

--- a/test/api/company_keywords/testCompanyKeywords.js
+++ b/test/api/company_keywords/testCompanyKeywords.js
@@ -14,23 +14,13 @@ describe('Company Keywords Test', function() {
     before(function() {
         return MongoClient.connect(config.get('MONGODB_URI')).then(function(_db) {
             db = _db;
-            return db.collections();
-        }).then((result) => {
-            const target_collection = result.find((collection) => {
-                if (collection.collectionName == "search_by_company_keywords'") {
-                    return collection;
-                }
-            });
-            if (!target_collection) {
-                return create_capped_collection(db);
-            }
         });
     });
 
 
-    describe('Get : /company_keywords', function() {
+    describe('Collection company_keywords', function() {
         it('should return true, if the collection is capped', function() {
-            return db.collection('search_by_company_keywords').isCapped()
+            return db.collection('company_keywords').isCapped()
                 .then((result) => {
                     assert.isTrue(result);
                 });
@@ -39,26 +29,27 @@ describe('Company Keywords Test', function() {
 
     describe('Get : /experiences (key word check)', function() {
         it('should return 200', function() {
-            const query = new ObjectId();
+            const query = (new ObjectId()).toString();
             return request(app).get('/experiences')
                 .query({
                     search_query: query.toString(),
-                    search_by: "company",
+                    search_by: 'company',
                 })
                 .expect(200)
                 .then(() => {
-                    return db.collection('search_by_company_keywords')
-                        .find({
-                            word: query.toString(),
-                        }).toArray();
+                    return db.collection('company_keywords')
+                        .findOne({
+                            word: query,
+                        });
                 })
                 .then((result) => {
-                    assert.equal(result[0].word, query.toString());
+                    assert.equal(result.word, query.toString());
                 });
         });
     });
 
     after(function() {
-        return db.collection('search_by_company_keywords').drop();
+        return db.collection('company_keywords').drop()
+            .then(() => create_capped_collection(db));
     });
 });

--- a/test/api/experiences/testExperiences.js
+++ b/test/api/experiences/testExperiences.js
@@ -507,9 +507,14 @@ describe('Experiences 面試和工作經驗資訊', function () {
 
         after(function () {
             return Promise.all([
-                db.collection('search_by_company_keywords').drop(),
-                db.collection('search_by_job_title_keywords').drop(),
-            ]);
+                db.collection('company_keywords').drop(),
+                db.collection('job_title_keywords').drop(),
+            ]).then(() => {
+                return Promise.all([
+                    create_title_keyword_collection(db),
+                    create_company_keyword_collection(db),
+                ]);
+            });
         });
     });
 });

--- a/test/api/experiences/testExperiences.js
+++ b/test/api/experiences/testExperiences.js
@@ -509,12 +509,10 @@ describe('Experiences 面試和工作經驗資訊', function () {
             return Promise.all([
                 db.collection('company_keywords').drop(),
                 db.collection('job_title_keywords').drop(),
-            ]).then(() => {
-                return Promise.all([
-                    create_title_keyword_collection(db),
-                    create_company_keyword_collection(db),
-                ]);
-            });
+            ]).then(() => Promise.all([
+                create_title_keyword_collection(db),
+                create_company_keyword_collection(db),
+            ]));
         });
     });
 });

--- a/test/api/job_title_keywords/testJobTitleKeywords.js
+++ b/test/api/job_title_keywords/testJobTitleKeywords.js
@@ -8,18 +8,18 @@ const app = require('../../../app');
 const config = require('config');
 const create_capped_collection = require('../../../database/migrations/create-jobTitleKeywords-collection');
 
-describe('Job title Keywords Test', function() {
+describe('Job title Keywords Test', function () {
     let db = null;
 
-    before(function() {
-        return MongoClient.connect(config.get('MONGODB_URI')).then(function(_db) {
+    before(function () {
+        return MongoClient.connect(config.get('MONGODB_URI')).then(function (_db) {
             db = _db;
         });
     });
 
 
-    describe('Collecction job_title_keywords', function() {
-        it('should return true, if the collection is capped', function() {
+    describe('Collecction job_title_keywords', function () {
+        it('should return true, if the collection is capped', function () {
             return db.collection('job_title_keywords').isCapped()
                     .then((result) => {
                         assert.isTrue(result);
@@ -27,8 +27,8 @@ describe('Job title Keywords Test', function() {
         });
     });
 
-    describe('Get : /experiences (key word check)', function() {
-        it('should return 200', function() {
+    describe('Get : /experiences (key word check)', function () {
+        it('should return 200', function () {
             const query = (new ObjectId()).toString();
             return request(app).get('/experiences')
                 .query({
@@ -36,19 +36,17 @@ describe('Job title Keywords Test', function() {
                     search_by: 'job_title',
                 })
                 .expect(200)
-                .then(() => {
-                    return db.collection('job_title_keywords')
+                .then(() => db.collection('job_title_keywords')
                         .findOne({
                             word: query.toString(),
-                        });
-                })
+                        }))
                 .then((result) => {
                     assert.equal(result.word, query.toString());
                 });
         });
     });
 
-    after(function() {
+    after(function () {
         return db.collection('job_title_keywords').drop()
             .then(() => create_capped_collection(db));
     });

--- a/test/api/job_title_keywords/testJobTitleKeywords.js
+++ b/test/api/job_title_keywords/testJobTitleKeywords.js
@@ -1,0 +1,65 @@
+const assert = require('chai').assert;
+const {
+    MongoClient,
+    ObjectId,
+} = require('mongodb');
+const request = require('supertest');
+const app = require('../../../app');
+const config = require('config');
+const create_capped_collection = require('../../../database/migrations/create-jobTitleKeywords-collection');
+
+describe('Job title Keywords Test', function() {
+    let db = null;
+
+    before(function() {
+        return MongoClient.connect(config.get('MONGODB_URI')).then(function(_db) {
+            db = _db;
+            return db.collections();
+        }).then((result) => {
+            const target_collection = result.find((collection) => {
+                if (collection.collectionName == "search_by_job_title_keywords") {
+                    return collection;
+                }
+            });
+            if (!target_collection) {
+                return create_capped_collection(db);
+            }
+        });
+    });
+
+
+    describe('Get : /job_title_keywords', function() {
+
+        it('should return true, if the collection is capped', function() {
+            return db.collection('search_by_job_title_keywords').isCapped()
+                    .then((result) => {
+                        assert.isTrue(result);
+                    });
+        });
+    });
+
+    describe('Get : /experiences (key word check)', function() {
+        it('should return 200', function() {
+            const query = new ObjectId();
+            return request(app).get('/experiences')
+                .query({
+                    search_query: query.toString(),
+                    search_by: "job_title",
+                })
+                .expect(200)
+                .then(() => {
+                    return db.collection('search_by_job_title_keywords')
+                        .find({
+                            word: query.toString(),
+                        }).toArray();
+                })
+                .then((result) => {
+                    assert.equal(result[0].word, query.toString());
+                });
+        });
+    });
+
+    after(function() {
+        return db.collection('search_by_job_title_keywords').drop();
+    });
+});

--- a/test/api/job_title_keywords/testJobTitleKeywords.js
+++ b/test/api/job_title_keywords/testJobTitleKeywords.js
@@ -14,24 +14,13 @@ describe('Job title Keywords Test', function() {
     before(function() {
         return MongoClient.connect(config.get('MONGODB_URI')).then(function(_db) {
             db = _db;
-            return db.collections();
-        }).then((result) => {
-            const target_collection = result.find((collection) => {
-                if (collection.collectionName == "search_by_job_title_keywords") {
-                    return collection;
-                }
-            });
-            if (!target_collection) {
-                return create_capped_collection(db);
-            }
         });
     });
 
 
-    describe('Get : /job_title_keywords', function() {
-
+    describe('Collecction job_title_keywords', function() {
         it('should return true, if the collection is capped', function() {
-            return db.collection('search_by_job_title_keywords').isCapped()
+            return db.collection('job_title_keywords').isCapped()
                     .then((result) => {
                         assert.isTrue(result);
                     });
@@ -40,26 +29,27 @@ describe('Job title Keywords Test', function() {
 
     describe('Get : /experiences (key word check)', function() {
         it('should return 200', function() {
-            const query = new ObjectId();
+            const query = (new ObjectId()).toString();
             return request(app).get('/experiences')
                 .query({
-                    search_query: query.toString(),
-                    search_by: "job_title",
+                    search_query: query,
+                    search_by: 'job_title',
                 })
                 .expect(200)
                 .then(() => {
-                    return db.collection('search_by_job_title_keywords')
-                        .find({
+                    return db.collection('job_title_keywords')
+                        .findOne({
                             word: query.toString(),
-                        }).toArray();
+                        });
                 })
                 .then((result) => {
-                    assert.equal(result[0].word, query.toString());
+                    assert.equal(result.word, query.toString());
                 });
         });
     });
 
     after(function() {
-        return db.collection('search_by_job_title_keywords').drop();
+        return db.collection('job_title_keywords').drop()
+            .then(() => create_capped_collection(db));
     });
 });


### PR DESCRIPTION
#247 

本次pr重點
1. 增加了在搜尋時，會將key word給存放起來。
2. 建立兩個 migration ，一個為建立`search_by_company_keywords `，另一個為`search_by_job_title_keywords `。
3. 增加測試，並且修改 `get \experiences` 的 `before`。