### PR TITLE
改善 POST /workings 驗證的流程

### DIFF
--- a/routes/workings.js
+++ b/routes/workings.js
@@ -7,6 +7,7 @@ const winston = require('winston');
 const escapeRegExp = require('lodash/escapeRegExp');
 const post_helper = require('./workings_post');
 const middleware = require('./middleware');
+const authentication = require('../middlewares/authentication');
 
 router.get('/', middleware.sort_by);
 router.get('/', middleware.pagination);
@@ -72,25 +73,8 @@ router.post('/', (req, res, next) => {
     next();
 });
 
-/*
- *  When developing, you can set environment to skip facebook auth
- */
-if (!process.env.SKIP_FACEBOOK_AUTH) {
-    router.post('/', (req, res, next) => {
-        const access_token = req.body.access_token;
-
-        facebook.accessTokenAuth(access_token).then((facebookInfo) => {
-            winston.info("facebook auth success", { access_token, ip: req.ip, ips: req.ips });
-
-            req.custom.facebook = facebookInfo;
-            next();
-        }).catch((err) => {
-            winston.info("facebook auth fail", { access_token, ip: req.ip, ips: req.ips });
-
-            next(new HttpError("Unauthorized", 401));
-        });
-    });
-}
+router.post('/', authentication.cachedFacebookAuthenticationMiddleware);
+// req.user.facebook --> {id, name}
 
 router.post('/', (req, res, next) => {
     post_helper.collectData(req, res).then(next, next);

--- a/routes/workings.js
+++ b/routes/workings.js
@@ -2,8 +2,6 @@ const express = require('express');
 
 const router = express.Router();
 const HttpError = require('../libs/errors').HttpError;
-const facebook = require('../libs/facebook');
-const winston = require('winston');
 const escapeRegExp = require('lodash/escapeRegExp');
 const post_helper = require('./workings_post');
 const middleware = require('./middleware');

--- a/routes/workings_post.js
+++ b/routes/workings_post.js
@@ -13,7 +13,7 @@ function checkBodyField(req, field) {
 }
 
 /*
- * [req.custom.facebook]
+ * req.user.facebook
  *
  * req.custom.working
  * req.custom.company_query
@@ -32,13 +32,10 @@ function collectData(req, res) {
         author.email = req.body.email;
     }
 
-    if (req.custom.facebook) {
-        author.id = req.custom.facebook.id;
-        author.name = req.custom.facebook.name;
+    if (req.user.facebook) {
+        author.id = req.user.facebook.id;
+        author.name = req.user.facebook.name;
         author.type = "facebook";
-    } else {
-        author.id = "-1";
-        author.type = "test";
     }
 
     // pick these fields only

--- a/test/testWorkingsPost.js
+++ b/test/testWorkingsPost.js
@@ -161,16 +161,15 @@ describe('Workings 工時資訊', () => {
                     .expect(401);
             });
 
-            it('需要回傳 401 如果不能 FB 登入', () => {
-                return request(app).post('/workings')
+            it('需要回傳 401 如果不能 FB 登入', () =>
+                request(app).post('/workings')
                     .send({
                         access_token: 'invalid',
                     })
                     .expect(401)
                     .then((res) => {
                         sinon.assert.calledOnce(cachedFacebookAuthentication);
-                    });
-            });
+                    }));
         });
 
         describe('generate payload', () => {

--- a/test/testWorkingsPost.js
+++ b/test/testWorkingsPost.js
@@ -6,7 +6,7 @@ const app = require('../app');
 const MongoClient = require('mongodb').MongoClient;
 const sinon = require('sinon');
 const config = require('config');
-const facebook = require('../libs/facebook');
+const authentication = require('../libs/authentication');
 const ObjectId = require('mongodb').ObjectId;
 
 function generateWorkingTimeRelatedPayload(options) {
@@ -115,7 +115,15 @@ function generateAllPayload(options) {
 describe('Workings 工時資訊', () => {
     let db;
     let sandbox;
-    let accessTokenAuth;
+    let cachedFacebookAuthentication;
+    const fake_user = {
+        _id: new ObjectId(),
+        facebook_id: '-1',
+        facebook: {
+            id: '-1',
+            name: 'mark',
+        },
+    };
 
     before('DB: Setup', () => MongoClient.connect(config.get('MONGODB_URI')).then((_db) => {
         db = _db;
@@ -123,8 +131,11 @@ describe('Workings 工時資訊', () => {
 
     beforeEach(() => {
         sandbox = sinon.sandbox.create();
-        accessTokenAuth = sandbox.stub(facebook, 'accessTokenAuth')
-            .resolves({ id: '-1', name: 'test' });
+        cachedFacebookAuthentication = sandbox.stub(authentication, 'cachedFacebookAuthentication');
+        cachedFacebookAuthentication.withArgs(sinon.match.object, sinon.match.object, 'random')
+            .resolves(fake_user);
+        cachedFacebookAuthentication.withArgs(sinon.match.object, sinon.match.object, 'invalid')
+            .rejects();
     });
 
     describe('POST /workings', () => {
@@ -146,43 +157,18 @@ describe('Workings 工時資訊', () => {
         describe('Authentication & Authorization Part', () => {
             it('需要回傳 401 如果沒有 access_token', () => {
                 sandbox.restore();
-                accessTokenAuth = sandbox.stub(facebook, 'accessTokenAuth')
-                    .rejects(new Error('access_token is invalid'));
-
                 return request(app).post('/workings')
-                    .expect(401)
-                    .then((res) => {
-                        sinon.assert.calledOnce(accessTokenAuth);
-                    });
-            });
-
-            it('需要回傳 401 如果 access_token 為空', () => {
-                sandbox.restore();
-                accessTokenAuth = sandbox.stub(facebook, 'accessTokenAuth')
-                    .rejects(new Error('access_token is invalid'));
-
-                return request(app).post('/workings')
-                    .send({
-                        access_token: "",
-                    })
-                    .expect(401)
-                    .then((res) => {
-                        sinon.assert.calledOnce(accessTokenAuth);
-                    });
+                    .expect(401);
             });
 
             it('需要回傳 401 如果不能 FB 登入', () => {
-                sandbox.restore();
-                accessTokenAuth = sandbox.stub(facebook, 'accessTokenAuth')
-                    .rejects(new Error('access_token is invalid'));
-
                 return request(app).post('/workings')
                     .send({
-                        access_token: 'random',
+                        access_token: 'invalid',
                     })
                     .expect(401)
                     .then((res) => {
-                        sinon.assert.calledOnce(accessTokenAuth);
+                        sinon.assert.calledOnce(cachedFacebookAuthentication);
                     });
             });
         });
@@ -941,7 +927,7 @@ describe('Workings 工時資訊', () => {
                         }))
                         .expect(429))
                 .then(() => {
-                    sinon.assert.callCount(accessTokenAuth, 6);
+                    sinon.assert.callCount(cachedFacebookAuthentication, 6);
                 });
             });
 
@@ -966,7 +952,7 @@ describe('Workings 工時資訊', () => {
                                 assert.equal(res.body.working.company.name, 'GOODJOB');
                             }))
                     .then(() => {
-                        sinon.assert.callCount(accessTokenAuth, 2);
+                        sinon.assert.callCount(cachedFacebookAuthentication, 2);
                     }));
         });
 

--- a/test/testWorkingsPost.js
+++ b/test/testWorkingsPost.js
@@ -179,7 +179,7 @@ describe('Workings 工時資訊', () => {
                     .expect(200);
 
                 assert.deepPropertyVal(res.body, 'working.author.id', '-1');
-                assert.deepPropertyVal(res.body, 'working.author.name', 'test');
+                assert.deepPropertyVal(res.body, 'working.author.name', 'mark');
                 assert.deepPropertyVal(res.body, 'working.author.type', 'facebook');
             });
 


### PR DESCRIPTION
## 做了什麼

這個是一開始寫的驗證流程，後來因為驗證功能很常使用

所以大部分都是用 `cachedFacebookAuthenticationMiddleware`，但唯一

沒有將這個 API 改寫

## 技術細節

* 原本的 code `req.custom.facebook = facebookInfo;`
* 後來的 code `req.user.facebook // a user's facebook info`

所以把一些用到 req.custom.facebook 稍作改寫
