### PR TITLE
CI run more test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ defaults: &defaults
             command: npm run migrate
         - run:
             name: Unit test and API test
+            command: npm run test -- --timeout 30s
+        - run:
+            name: Unit test and API test
             command: npm run test:coverage -- --timeout 30s
         - run:
             name: Coveralls


### PR DESCRIPTION
Coverage 測試對於不支援的 syntax 不會報錯, see #411 ，故增加只有 mocha 指令的測試