### PR TITLE
fix POST /experiences/:id/reports validation problem

### DIFF
--- a/routes/experiences/reports.js
+++ b/routes/experiences/reports.js
@@ -18,7 +18,7 @@ function validatePostFields(body) {
     if (!shouldIn(body.reason_category, ["這是廣告或垃圾訊息", "我認為這篇文章涉及人身攻擊、誹謗", "我認為這篇文章內容不實", "其他"])) {
         throw new HttpError("檢舉原因分類錯誤", 422);
     }
-    if (body.reason_category !== "這是廣告或垃圾訊息 ") {
+    if (body.reason_category !== "這是廣告或垃圾訊息") {
         if (!requiredNonEmptyString(body.reason)) {
             throw new HttpError("原因必填！", 422);
         } else if (!stringRequireLength(body.reason, 1, 500)) {

--- a/routes/experiences/reports.test.js
+++ b/routes/experiences/reports.test.js
@@ -109,6 +109,32 @@ describe('Reports Test', () => {
                 })
                 .expect(422));
 
+        it('should return 200 and correct fields, while reason_category is "這是廣告或垃圾訊息" and reason is undefined', () => request(app)
+                .post(`/experiences/${experience_id_str}/reports`)
+                .send({
+                    access_token: 'fakeaccesstoken',
+                    reason_category: '這是廣告或垃圾訊息',
+                })
+                .expect(200)
+                .expect((res) => {
+                    assert.property(res.body, 'report');
+                    assert.deepProperty(res.body, 'report._id');
+                    assert.deepPropertyVal(res.body, 'report.reason_category', '這是廣告或垃圾訊息');
+                    assert.notDeepProperty(res.body, 'report.reason');
+                    assert.deepProperty(res.body, 'report.created_at');
+                    assert.notDeepProperty(res.body, 'report.user');
+                })
+        );
+
+        it('should fail while reason_category is not "這是廣告或垃圾訊息" and reason is undefiend', () => request(app)
+                .post(`/experiences/${experience_id_str}/reports`)
+                .send({
+                    access_token: 'fakeaccesstoken',
+                    reason_category: '我認為這篇文章內容不實',
+                })
+                .expect(422));
+
+
         it('should return 404, if experience does not exist', () => request(app)
                 .post('/experiences/1111/reports')
                 .send(generatePayload('fakeaccesstoken'))


### PR DESCRIPTION
解掉 POST /experiences/:id/reports validation 錯誤的問題，並加上兩個測試