### PR TITLE
PR-使用者管理資料 replies 查詢時需要根據 status 顯示隱藏

### DIFF
--- a/models/reply_like_model.js
+++ b/models/reply_like_model.js
@@ -23,7 +23,7 @@ class ReplyLikeModel {
     createLike(reply_id, user) {
         const reply_model = new ReplyModel(this._db);
 
-        return reply_model.getReplyById(reply_id).then((reply) => {
+        return reply_model.getPublishedReplyById(reply_id).then((reply) => {
             if (!reply) {
                 throw new ObjectNotExistError("這篇留言不存在");
             }
@@ -79,7 +79,7 @@ class ReplyLikeModel {
     deleteLike(reply_id, user) {
         const reply_model = new ReplyModel(this._db);
 
-        return reply_model.getReplyById(reply_id).then((reply) => {
+        return reply_model.getPublishedReplyById(reply_id).then((reply) => {
             if (!reply) {
                 throw new ObjectNotExistError("這篇留言不存在");
             }

--- a/models/reply_model.js
+++ b/models/reply_model.js
@@ -109,6 +109,7 @@ class ReplyModel {
             }
             return this.collection.find({
                 experience_id: new ObjectId(experience_id),
+                status: "published",
             }).sort(sort).skip(skip).limit(limit)
             .toArray();
         });
@@ -133,6 +134,7 @@ class ReplyModel {
 
         return this.collection.findOne({
             _id: new ObjectId(id),
+            status: "published",
         });
     }
 

--- a/models/reply_model.js
+++ b/models/reply_model.js
@@ -82,7 +82,7 @@ class ReplyModel {
     }
 
     /**
-     * 根據經驗文章id，取得文章留言
+     * 根據經驗文章id，取得 published 的留言
      * @param {string} experience_id - experience's id
      * @param {number} skip - start index (Default: 0)
      * @param {number} limit - limit (Default: 20)
@@ -139,7 +139,7 @@ class ReplyModel {
     }
 
     /**
-     * 根據reply id 來取得 published 留言
+     * 根據reply id 來取得 published 的留言
      * @param {string} id - reply id
      * @returns {Promise} -
      * resolve {

--- a/models/reply_model.js
+++ b/models/reply_model.js
@@ -100,7 +100,7 @@ class ReplyModel {
      *      report_count: 0,
      *  }
      */
-    getRepliesByExperienceId(experience_id, skip = 0, limit = 20, sort = {
+    getPublishedRepliesByExperienceId(experience_id, skip = 0, limit = 20, sort = {
         floor: 1,
     }) {
         const experience_model = new ExperienceModel(this._db);
@@ -135,7 +135,29 @@ class ReplyModel {
 
         return this.collection.findOne({
             _id: new ObjectId(id),
-            status: "published",
+        });
+    }
+
+    /**
+     * 根據reply id 來取得 published 留言
+     * @param {string} id - reply id
+     * @returns {Promise} -
+     * resolve {
+     *  _id : ObjectId,
+     *  experience_id : ObjectId,
+     *  author_id: ObjectId,
+     *  created_at: new Date(),
+     *  like_count: 0,
+     * }
+     */
+    getPublishedReplyById(id) {
+        if (!this._isValidId(id)) {
+            return Promise.reject(new ObjectNotExistError("該留言不存在"));
+        }
+
+        return this.collection.findOne({
+            status: 'published',
+            _id: new ObjectId(id),
         });
     }
 

--- a/routes/experiences/replies.js
+++ b/routes/experiences/replies.js
@@ -142,7 +142,8 @@ router.get('/:id/replies', [
             const reply_model = new ReplyModel(req.db);
             const reply_like_model = new ReplyLikeModel(req.db);
 
-            const replies = await reply_model.getRepliesByExperienceId(experience_id, start, limit);
+            const replies = await reply_model
+                        .getPublishedRepliesByExperienceId(experience_id, start, limit);
             const replies_ids = replies.map(reply => reply._id);
             const likes = await reply_like_model.getReplyLikesByRepliesIds(replies_ids);
             _createLikesField(replies, likes, user);

--- a/routes/experiences/replies.test.js
+++ b/routes/experiences/replies.test.js
@@ -6,6 +6,7 @@ const sinon = require('sinon');
 const config = require('config');
 
 const authentication = require('../../libs/authentication');
+const { generateReplyData } = require('../experiences/testData');
 
 describe('Replies Test', () => {
     let db;
@@ -163,19 +164,21 @@ describe('Replies Test', () => {
             experience_id = result.insertedId;
             experience_id_string = result.insertedId.toString();
 
-            const testDatas = [];
+            const test_replies = [];
             for (let i = 0; i < TEST_REPLIES_COUNT; i += 1) {
-                testDatas.push({
-                    created_at: new Date(),
+                test_replies.push(Object.assign(generateReplyData(), {
                     experience_id,
                     author_id: fake_user._id,
-                    content: "hello test0",
-                    like_count: 0,
-                    report_count: 0,
                     floor: i,
-                });
+                }));
             }
-            return db.collection('replies').insertMany(testDatas);
+            test_replies.push(Object.assign(generateReplyData(), {
+                experience_id,
+                author_id: fake_user._id,
+                status: 'hidden',
+            }));
+
+            return db.collection('replies').insertMany(test_replies);
         }).then((result) => {
             const reply1 = result.ops[0];
             const reply2 = result.ops[1];

--- a/routes/experiences/replies.test.js
+++ b/routes/experiences/replies.test.js
@@ -229,6 +229,19 @@ describe('Replies Test', () => {
                     assert.lengthOf(res.body.replies, TEST_REPLIES_COUNT);
                 }));
 
+        it('get experiences replies data and expect 200 replies (total is 201) ', () => request(app)
+                .get(`/experiences/${experience_id_string}/replies`)
+                .query({
+                    limit: 999,
+                })
+                .expect(200)
+                .expect((res) => {
+                    assert.property(res.body, 'replies');
+                    assert.notDeepProperty(res.body, 'replies.0.author_id');
+                    assert.isArray(res.body.replies);
+                    assert.lengthOf(res.body.replies, 200);
+                }));
+
         it('should not see liked (true/false) if not autheticated', () => request(app)
                 .get(`/experiences/${experience_id_string}/replies`)
                 .expect(200)

--- a/routes/experiences/testData.js
+++ b/routes/experiences/testData.js
@@ -125,9 +125,22 @@ function generateWorkingData() {
     };
 }
 
+function generateReplyData() {
+    return {
+        created_at: new Date(),
+        experience_id: new ObjectId(),
+        author_id: new ObjectId(),
+        content: "hello test0",
+        like_count: 0,
+        report_count: 0,
+        floor: 1,
+        status: "published",
+    };
+}
 
 module.exports = {
     generateInterviewExperienceData,
     generateWorkExperienceData,
     generateWorkingData,
+    generateReplyData,
 };

--- a/routes/replies/likes.test.js
+++ b/routes/replies/likes.test.js
@@ -29,13 +29,13 @@ describe('POST /replies/:id/likes', () => {
     }));
 
     beforeEach('Seed reply', async () => {
-        const published_reply = Object.assign(generateReplyData(),{
+        const published_reply = Object.assign(generateReplyData(), {
             experience_id,
             like_count: 0,
             status: 'published',
         });
 
-        const hidden_reply = Object.assign(generateReplyData(),{
+        const hidden_reply = Object.assign(generateReplyData(), {
             experience_id,
             like_count: 0,
             status: 'hidden',


### PR DESCRIPTION
#432 
本次修改重點

1. Get /experiences/:id/replies 增加 filter status = "published" (model層處理)
2. Delete&Post  /replies/:id/likes 增加 filter status = "published" (model層處理)
3. 新增與修改測試

P.S 這個 model 層，有點做太多超出他該做的工作，status 應該是要在 route 層修改，之後重構時，再來處理吧。