### PR TITLE
Model 抽象化

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,7 +4,7 @@ const config = require("config");
 const cors = require("cors");
 const express = require("express");
 const expressMongoDb = require("express-mongo-db");
-const { HttpError } = require("./libs/errors");
+const { HttpError, ObjectNotExistError } = require("./libs/errors");
 const logger = require("morgan");
 const winston = require("winston");
 // eslint-disable-next-line no-unused-expressions
@@ -74,6 +74,11 @@ app.use((req, res, next) => {
 
 // logging any error except HttpError
 app.use((err, req, res, next) => {
+    if (err instanceof ObjectNotExistError) {
+        next(new HttpError("Not Found", 404));
+        return;
+    }
+
     if (err instanceof HttpError) {
         next(err);
         return;

--- a/models/experience_model.js
+++ b/models/experience_model.js
@@ -62,42 +62,19 @@ class ExperienceModel {
     }
 
     /**
-     * 使用 experience _id 來取得單篇文章
-     * @param   {string}  id - experience_id
+     * 透過 _id 來取得單篇文章
+     * @param {ObjectId} _id - experience_id
      * @param {object} opt - mongodb find field filter
      * @returns {Promise}
-     *  - resolved : {
-     *      type : "interview",
-     *      created_at : Date Object,
-     *      company : {
-     *          id : 1234,
-     *          name : "GoodJob"
-     *      }
-     *      job_title : "Backend Developer",
-     *      sections : [
-     *          {subtitle:"XXX",content:"Hello world"}
-     *      ],
-     *
+     *  - resolved : Experience
      *  - reject : ObjectNotExistError/Default Error
      */
-    getExperienceById(id, opt = {}) {
-        if (!this._isValidId(id)) {
-            return Promise.reject(new ObjectNotExistError("該文章不存在"));
+    async findOneOrFail(_id, opt = {}) {
+        const experience = await this.collection.findOne({ _id }, opt);
+        if (experience) {
+            return experience;
         }
-
-        return this.collection
-            .findOne(
-                {
-                    _id: new mongo.ObjectId(id),
-                },
-                opt
-            )
-            .then(result => {
-                if (result) {
-                    return result;
-                }
-                throw new ObjectNotExistError("該文章不存在");
-            });
+        throw new ObjectNotExistError("該文章不存在");
     }
 
     // eslint-disable-next-line class-methods-use-this

--- a/models/index.js
+++ b/models/index.js
@@ -1,0 +1,18 @@
+const { ObjectId } = require("mongodb");
+const { ObjectNotExistError } = require("../libs/errors");
+
+module.exports.ensureToObjectId = function(id_string) {
+    if (id_string instanceof ObjectId) {
+        return id_string;
+    }
+
+    if (typeof id_string !== "string") {
+        throw new ObjectNotExistError("id_string 必須是 string");
+    }
+
+    if (ObjectId.isValid(id_string) !== true) {
+        throw new ObjectNotExistError("id_string 不是合法的 ObjectId");
+    }
+
+    return new ObjectId(id_string);
+};

--- a/models/index.test.js
+++ b/models/index.test.js
@@ -1,0 +1,30 @@
+const { assert } = require("chai");
+const { ObjectId } = require("mongodb");
+const { ObjectNotExistError } = require("../libs/errors");
+const { ensureToObjectId } = require("./");
+
+describe("ensureToObjectId", () => {
+    it("will return ObjectId", () => {
+        const obj = ensureToObjectId("59afe149707f743bb38d495f");
+
+        assert.instanceOf(obj, ObjectId);
+    });
+
+    it("will return ObjectId if ObjectId given", () => {
+        const obj = ensureToObjectId(new ObjectId());
+
+        assert.instanceOf(obj, ObjectId);
+    });
+
+    it("will throw ObjectNotExistError if parameter is not string", () => {
+        assert.throws(() => {
+            ensureToObjectId(123);
+        }, ObjectNotExistError);
+    });
+
+    it("will throw ObjectNotExistError if parameter is not a valid ObjectId", () => {
+        assert.throws(() => {
+            ensureToObjectId("123");
+        }, ObjectNotExistError);
+    });
+});

--- a/routes/me/replies/index.js
+++ b/routes/me/replies/index.js
@@ -85,7 +85,7 @@ router.get("/", [
         const experience_promises = replies
             .map(reply => reply.experience_id)
             .map(_id =>
-                experience_model.getExperienceById(_id.toString(), {
+                experience_model.findOneOrFail(_id, {
                     _id: 1,
                     title: 1,
                 })


### PR DESCRIPTION
問題：

1. 很常需要將 `id_string` 轉換成 `ObjectId`，目前在每個 Model 都有 `_isValidId` 做檢查，很重複
2. Model 常常在 query 時會丟出 `ObjectNotExistError`，每次都需要在 route handler 轉成 `HttpError`，很重複

解法：

1. 新增 `ensureObjectId`，當不合法的 id 傳入，即會拋出 `ObjectNotExistError` 錯誤
2. 明確在 model 的方法寫出可能的結果，例如：findOrFail，代表找不到就拋出 `ObjectNotExistError` 錯誤
3. 在 app.js 攔截 1., 2. 的 `ObjectNotExistError` 錯誤，轉換成 `HttpError`

這樣在寫新的 Route Handler 時，可以比較簡潔一些，try catch 可以少用很多