### PR TITLE
PR-[使用者編輯自己的資料] 編輯經驗分享 API

### DIFF
--- a/models/experience_history_model.js
+++ b/models/experience_history_model.js
@@ -1,0 +1,11 @@
+class ExperienceHistoryModel {
+    constructor(db) {
+        this.collection = db.collection("experiences_history");
+    }
+
+    createExperienceHistory(old_experience) {
+        return this.collection.insertOne(old_experience);
+    }
+}
+
+module.exports = ExperienceHistoryModel;

--- a/models/experience_history_model.js
+++ b/models/experience_history_model.js
@@ -2,9 +2,13 @@ class ExperienceHistoryModel {
     constructor(db) {
         this.collection = db.collection("experiences_history");
     }
-
-    createExperienceHistory(old_experience) {
-        return this.collection.insertOne(old_experience);
+    /**
+     * @param  {object} experience_history - Most of field equals experience model.
+     * @param  {string} experience_history.ref_id - it equals experience _id.
+     * @param  {updated_at} experience_history.updated_at - update time.
+     */
+    createExperienceHistory(experience_history) {
+        return this.collection.insertOne(experience_history);
     }
 }
 

--- a/models/experience_model.js
+++ b/models/experience_model.js
@@ -253,7 +253,9 @@ class ExperienceModel {
             {
                 _id: id,
             },
-            new_experience
+            {
+                $set: new_experience,
+            }
         );
     }
 }

--- a/models/experience_model.js
+++ b/models/experience_model.js
@@ -249,7 +249,7 @@ class ExperienceModel {
         );
     }
     updateExperienceById(id, new_experience) {
-        return this.collection.update(
+        return this.collection.findOneAndUpdate(
             {
                 _id: id,
             },

--- a/models/experience_model.js
+++ b/models/experience_model.js
@@ -248,6 +248,14 @@ class ExperienceModel {
             }
         );
     }
+    updateInterviewExperienceById(id, new_experience) {
+        return this.collection.update(
+            {
+                _id: id,
+            },
+            new_experience
+        );
+    }
 }
 
 module.exports = ExperienceModel;

--- a/models/experience_model.js
+++ b/models/experience_model.js
@@ -248,10 +248,10 @@ class ExperienceModel {
             }
         );
     }
-    updateExperienceById(id, new_experience) {
+    updateExperienceById(_id, new_experience) {
         return this.collection.findOneAndUpdate(
             {
-                _id: id,
+                _id,
             },
             {
                 $set: new_experience,

--- a/models/experience_model.js
+++ b/models/experience_model.js
@@ -248,7 +248,7 @@ class ExperienceModel {
             }
         );
     }
-    updateInterviewExperienceById(id, new_experience) {
+    updateExperienceById(id, new_experience) {
         return this.collection.update(
             {
                 _id: id,

--- a/models/model_maps.js
+++ b/models/model_maps.js
@@ -1,0 +1,9 @@
+module.exports = {
+    experienceToHistoryMap(experience) {
+        const result = experience;
+        result.ref_id = experience._id;
+        result.updated_at = new Date();
+        delete result._id;
+        return result;
+    },
+};

--- a/routes/interview_experiences/index.js
+++ b/routes/interview_experiences/index.js
@@ -381,7 +381,7 @@ router.post("/", [
 ]);
 
 /**
- * @api {put} /interview_experiences 更新面試經驗 API
+ * @api {put} /interview_experiences 修改面試經驗 API
  * @apiGroup Interview_Experiences
  * @apiParam {String} company_query 公司名稱 或 統一編號
  * @apiParam {String} [company_id] 公司統編 (如果自動完成有成功，會拿的到 company_id )
@@ -414,9 +414,7 @@ router.post("/", [
     "曾要求繳交身分證","曾要求繳交保證金","曾詢問宗教信仰",
     "或其他 0 < length <= 20 的字串"} [interview_sensitive_questions] 面試中提及的特別問題陣列(較敏感/可能違法)
  * @apiParam {String="published","hidden"} [status="published"] 該篇文章的狀態
- * @apiSuccess {Boolean} success 是否上傳成功
- * @apiSuccess {Object} experience 經驗分享物件
- * @apiSuccess {String} experience._id 經驗分享id
+ * @apiSuccess {Boolean} success 是否修改成功
  */
 router.put("/:id", [
     passport.authenticate("bearer", { session: false }),
@@ -460,7 +458,7 @@ router.put("/:id", [
             updated_at: new Date(),
         });
 
-        const result = await experience_model.updateInterviewExperienceById(
+        const result = await experience_model.updateExperienceById(
             id,
             experience
         );

--- a/routes/interview_experiences/index.js
+++ b/routes/interview_experiences/index.js
@@ -443,14 +443,7 @@ router.put("/:id", [
         Object.assign(experience, {
             type: "interview",
             author_id: user._id,
-            company: (async () => {
-                const company = await helper.getCompanyByIdOrQuery(
-                    req.db,
-                    req.body.company_id,
-                    req.body.company_query
-                );
-                return company;
-            })(),
+            company: old_experience.company,
             like_count: old_experience.like_count,
             reply_count: old_experience.reply_count,
             report_count: old_experience.report_count,

--- a/routes/interview_experiences/index.js
+++ b/routes/interview_experiences/index.js
@@ -14,6 +14,7 @@ const {
     stringRequireLength,
 } = require("../../libs/validation");
 const wrap = require("../../libs/wrap");
+const { ensureToObjectId } = require("../../models/index");
 
 function validateCommonInputFields(data) {
     if (!requiredNonEmptyString(data.company_query)) {
@@ -329,7 +330,7 @@ router.post("/", [
         Object.assign(experience, {
             type: "interview",
             author_id: req.user._id,
-            // company 後面決定
+            // company 後面決
             company: {},
             like_count: 0,
             reply_count: 0,
@@ -416,7 +417,7 @@ router.post("/", [
  * @apiSuccess {Object} experience 經驗分享物件
  * @apiSuccess {String} experience._id 經驗分享id
  */
-router.put("/", [
+router.put("/:id", [
     passport.authenticate("bearer", { session: false }),
     wrap(async (req, res, next) => {
         const id_str = req.params.id;
@@ -426,7 +427,8 @@ router.put("/", [
 
         const experience = {};
         const experience_model = new ExperienceModel(req.db);
-        const old_experience = experience_model.findOneOrFail(id_str);
+        const id = ensureToObjectId(id_str);
+        const old_experience = await experience_model.findOneOrFail(id);
 
         if (!old_experience.author_id.equals(user._id)) {
             throw new HttpError("user is unauthorized", 403);
@@ -447,6 +449,7 @@ router.put("/", [
             like_count: old_experience.like_count,
             reply_count: old_experience.reply_count,
             report_count: old_experience.report_count,
+            created_at: old_experience.created_at,
             updated_at: new Date(),
         });
 

--- a/routes/interview_experiences/index.js
+++ b/routes/interview_experiences/index.js
@@ -331,7 +331,7 @@ router.post("/", [
         Object.assign(experience, {
             type: "interview",
             author_id: req.user._id,
-            // company 後面決
+            // company 後面決定
             company: {},
             like_count: 0,
             reply_count: 0,
@@ -457,10 +457,7 @@ router.put("/:id", [
         );
 
         res.send({
-            success: true,
-            experience: {
-                _id: result._id,
-            },
+            success: result.ok === 1,
         });
     }),
 ]);

--- a/routes/interview_experiences/index.js
+++ b/routes/interview_experiences/index.js
@@ -13,6 +13,7 @@ const {
     shouldIn,
     stringRequireLength,
 } = require("../../libs/validation");
+const wrap = require("../../libs/wrap");
 
 function validateCommonInputFields(data) {
     if (!requiredNonEmptyString(data.company_query)) {
@@ -377,4 +378,89 @@ router.post("/", [
     },
 ]);
 
+/**
+ * @api {put} /interview_experiences 更新面試經驗 API
+ * @apiGroup Interview_Experiences
+ * @apiParam {String} company_query 公司名稱 或 統一編號
+ * @apiParam {String} [company_id] 公司統編 (如果自動完成有成功，會拿的到 company_id )
+ * @apiParam {String=
+    "彰化縣","嘉義市","嘉義縣","新竹市","新竹縣",
+    "花蓮縣","高雄市","基隆市","金門縣","連江縣",
+    "苗栗縣","南投縣","新北市","澎湖縣","屏東縣",
+    "臺中市","臺南市","臺北市","臺東縣","桃園市",
+    "宜蘭縣","雲林縣" } region 面試地區
+ * @apiParam {String} job_title 應徵職稱
+ * @apiParam {Number="整數, 0 <= N <= 50"} [experience_in_year] 相關職務工作經驗
+ * @apiParam {String="大學","碩士","博士","高職","五專","二專","二技","高中","國中","國小"} [education] 最高學歷
+ * @apiParam {Object} interview_time 面試時間
+ * @apiParam {Number="整數, N >= current_year - 10"} interview_time.year 面試時間的年份
+ * @apiParam {Number="1,2,3...12"} interview_time.month 面試時間的月份
+ * @apiParam {String="錄取,未錄取,沒通知,或其他 0 < length <= 10 的字串"} interview_result 面試結果
+ * @apiParam {Object} [salary] 面談薪資
+ * @apiParam {String="year","month","day","hour"} salary.type 面談薪資種類 (若有上傳面談薪資欄位，本欄必填)
+ * @apiParam {Number="整數, >= 0"} salary.amount 面談薪資金額 (若有上傳面談薪資欄位，本欄必填)
+ * @apiParam {Number="整數, 1~5"} overall_rating 整體面試滿意度
+ * @apiParam {String="0 < length <= 25 "} title 整篇經驗分享的標題
+ * @apiParam {Object[]} sections 整篇內容
+ * @apiParam {String="0 < length <= 25"} sections.subtitle 段落標題
+ * @apiParam {String="0 < length <= 5000"} sections.content 段落內容
+ * @apiParam {Object[]="Array maximum size: 30"} [interview_qas] 面試題目列表
+ * @apiParam {String="0 < length <= 250"} interview_qas.question 面試題目 (interview_qas有的話，必填)
+ * @apiParam {String="0 < length <= 5000"} [interview_qas.answer] 面試題目的回答 (interview_qas有的話，選填)
+ * @apiParam {String[]=
+    "曾詢問家庭狀況","曾詢問婚姻狀況","生育計畫",
+    "曾要求繳交身分證","曾要求繳交保證金","曾詢問宗教信仰",
+    "或其他 0 < length <= 20 的字串"} [interview_sensitive_questions] 面試中提及的特別問題陣列(較敏感/可能違法)
+ * @apiParam {String="published","hidden"} [status="published"] 該篇文章的狀態
+ * @apiSuccess {Boolean} success 是否上傳成功
+ * @apiSuccess {Object} experience 經驗分享物件
+ * @apiSuccess {String} experience._id 經驗分享id
+ */
+router.put("/", [
+    passport.authenticate("bearer", { session: false }),
+    wrap(async (req, res, next) => {
+        const id_str = req.params.id;
+        const user = req.user;
+
+        validationInputFields(req.body);
+
+        const experience = {};
+        const experience_model = new ExperienceModel(req.db);
+        const old_experience = experience_model.findOneOrFail(id_str);
+
+        if (!old_experience.author_id.equals(user._id)) {
+            throw new HttpError("user is unauthorized", 403);
+        }
+
+        Object.assign(experience, pickupInterviewExperience(req.body));
+        Object.assign(experience, {
+            type: "interview",
+            author_id: user._id,
+            company: (async () => {
+                const company = await helper.getCompanyByIdOrQuery(
+                    req.db,
+                    req.body.company_id,
+                    req.body.company_query
+                );
+                return company;
+            })(),
+            like_count: old_experience.like_count,
+            reply_count: old_experience.reply_count,
+            report_count: old_experience.report_count,
+            updated_at: new Date(),
+        });
+
+        const result = await experience_model.updateInterviewExperienceById(
+            old_experience._id,
+            experience
+        );
+
+        res.send({
+            success: true,
+            experience: {
+                _id: result._id,
+            },
+        });
+    }),
+]);
 module.exports = router;

--- a/routes/interview_experiences/index.js
+++ b/routes/interview_experiences/index.js
@@ -440,16 +440,7 @@ router.put("/:id", [
         await experience_history_model.createExperienceHistory(old_experience);
 
         Object.assign(experience, pickupInterviewExperience(req.body));
-        Object.assign(experience, {
-            type: "interview",
-            author_id: user._id,
-            company: old_experience.company,
-            like_count: old_experience.like_count,
-            reply_count: old_experience.reply_count,
-            report_count: old_experience.report_count,
-            created_at: old_experience.created_at,
-            updated_at: new Date(),
-        });
+        experience.updated_at = new Date();
 
         const result = await experience_model.updateExperienceById(
             id,

--- a/routes/interview_experiences/index.js
+++ b/routes/interview_experiences/index.js
@@ -16,6 +16,7 @@ const {
 } = require("../../libs/validation");
 const wrap = require("../../libs/wrap");
 const { ensureToObjectId } = require("../../models/index");
+const { experienceToHistoryMap } = require("../../models/model_maps");
 
 function validateCommonInputFields(data) {
     if (!requiredNonEmptyString(data.company_query)) {
@@ -434,10 +435,10 @@ router.put("/:id", [
             throw new HttpError("user is unauthorized", 403);
         }
 
-        old_experience.ref_id = id;
-        old_experience.time_stamp = new Date();
-        delete old_experience._id;
-        await experience_history_model.createExperienceHistory(old_experience);
+        const experience_history = experienceToHistoryMap(old_experience);
+        await experience_history_model.createExperienceHistory(
+            experience_history
+        );
 
         Object.assign(experience, pickupInterviewExperience(req.body));
         experience.updated_at = new Date();

--- a/routes/interview_experiences/index.test.js
+++ b/routes/interview_experiences/index.test.js
@@ -861,6 +861,7 @@ describe("更新面試經驗 Interview Experience", () => {
         const new_interview_experience = generateInterviewExperiencePayload({
             job_title: "我被修改了",
         });
+
         const res = await request(app)
             .put(`/interview_experiences/${user_old_experience_id_str}`)
             .send(new_interview_experience);
@@ -872,7 +873,21 @@ describe("更新面試經驗 Interview Experience", () => {
             _id: new ObjectId(user_old_experience_id_str),
         });
 
+        const keys = Object.keys(user_old_experience);
+        keys.forEach(value => {
+            assert.deepProperty(
+                experience,
+                value,
+                "Checking the new experience field equal old experience"
+            );
+        });
+
         assert.deepPropertyVal(experience, "job_title", "我被修改了");
+        assert.deepPropertyVal(
+            experience,
+            "company.id",
+            user_old_experience.company.id
+        );
         assert.deepPropertyVal(
             experience,
             "like_count",
@@ -890,19 +905,18 @@ describe("更新面試經驗 Interview Experience", () => {
         );
         assert.deepProperty(experience, "updated_at");
         assert.equal(experience.updated_at.getDate(), new Date().getDate());
+
         assert.deepProperty(experience, "created_at");
         assert.equal(
             experience.created_at.getDate(),
             user_old_experience.created_at.getDate()
         );
 
-        const old_experience = await db
-            .collection("experiences_history")
-            .findOne({
-                ref_id: new ObjectId(user_old_experience_id_str),
-            });
-        assert.deepProperty(old_experience, "time_stamp");
-        assert.deepProperty(old_experience, "ref_id");
+        const history = await db.collection("experiences_history").findOne({
+            ref_id: new ObjectId(user_old_experience_id_str),
+        });
+        assert.deepProperty(history, "time_stamp");
+        assert.deepProperty(history, "ref_id");
     });
     it("should return 403, when a user update other user`s experience", async () => {
         const new_interview_experience = generateInterviewExperiencePayload({

--- a/routes/interview_experiences/index.test.js
+++ b/routes/interview_experiences/index.test.js
@@ -10,6 +10,7 @@ const ObjectId = require("mongodb").ObjectId;
 const sinon = require("sinon");
 const config = require("config");
 const authentication = require("../../libs/authentication");
+const { generateInterviewExperienceData } = require("../experiences/testData");
 
 function generateInterviewExperiencePayload(options) {
     const opt = options || {};
@@ -767,5 +768,154 @@ describe("experiences 面試和工作經驗資訊", () => {
         afterEach(() => {
             sandbox.restore();
         });
+    });
+});
+
+describe("更新面試經驗 Interview Experience", () => {
+    let db;
+    let sandbox;
+    let user_old_experience;
+    let other_user_old_experience;
+    let user_old_experience_id_str;
+    let other_user_old_experience_id_str;
+    const fake_user = {
+        _id: new ObjectId(),
+        facebook_id: "-1",
+        facebook: {
+            id: "-1",
+            name: "markLin",
+        },
+    };
+
+    const other_fake_user = {
+        _id: new ObjectId(),
+        facebook_id: "-2",
+        facebook: {
+            id: "-2",
+            name: "lin",
+        },
+    };
+
+    before("DB: Setup", () =>
+        MongoClient.connect(config.get("MONGODB_URI")).then(_db => {
+            db = _db;
+        })
+    );
+
+    before("Seed companies", () =>
+        db.collection("companies").insertMany([
+            {
+                id: "00000001",
+                name: "GOODJOB",
+            },
+            {
+                id: "00000002",
+                name: "GOODJOBGREAT",
+            },
+            {
+                id: "00000003",
+                name: "GOODJOBGREAT",
+            },
+        ])
+    );
+
+    before("Create Data", async () => {
+        user_old_experience = Object.assign(generateInterviewExperienceData(), {
+            status: "published",
+            author_id: fake_user._id,
+            like_count: 10,
+            reply_count: 10,
+            report_count: 1,
+            created_at: (() => {
+                const date = new Date();
+                date.setDate(date.getDate() - 1);
+                return date;
+            })(),
+        });
+
+        other_user_old_experience = Object.assign(
+            generateInterviewExperienceData(),
+            {
+                status: "published",
+                author_id: other_fake_user._id,
+            }
+        );
+
+        const insert_result = await db
+            .collection("experiences")
+            .insertMany([user_old_experience, other_user_old_experience]);
+
+        user_old_experience_id_str = insert_result.insertedIds[0].toString();
+        other_user_old_experience_id_str = insert_result.insertedIds[1].toString();
+    });
+
+    before("Stub cachedFacebookAuthentication", () => {
+        sandbox = sinon.sandbox.create();
+        sandbox
+            .stub(authentication, "cachedFacebookAuthentication")
+            .withArgs(sinon.match.object, sinon.match.object, "fakeaccesstoken")
+            .resolves(fake_user);
+    });
+
+    it("should be success, when the author update experience", async () => {
+        const new_interview_experience = generateInterviewExperiencePayload({
+            job_title: "我被修改了",
+        });
+        const res = await request(app)
+            .put(`/interview_experiences/${user_old_experience_id_str}`)
+            .send(new_interview_experience);
+
+        assert.equal(res.status, 200);
+        assert.equal(res.body.success, true);
+
+        const experience = await db.collection("experiences").findOne({
+            _id: new ObjectId(user_old_experience_id_str),
+        });
+
+        assert.deepPropertyVal(experience, "job_title", "我被修改了");
+        assert.deepPropertyVal(
+            experience,
+            "like_count",
+            user_old_experience.like_count
+        );
+        assert.deepPropertyVal(
+            experience,
+            "reply_count",
+            user_old_experience.reply_count
+        );
+        assert.deepPropertyVal(
+            experience,
+            "report_count",
+            user_old_experience.report_count
+        );
+        assert.deepProperty(experience, "updated_at");
+        assert.equal(experience.updated_at.getDate(), new Date().getDate());
+        assert.deepProperty(experience, "created_at");
+        assert.equal(
+            experience.created_at.getDate(),
+            user_old_experience.created_at.getDate()
+        );
+    });
+    it("should return 403, when a user update other user`s experience", async () => {
+        const new_interview_experience = generateInterviewExperiencePayload({
+            job_title: "我被修改了",
+        });
+
+        const res = await request(app)
+            .put(`/interview_experiences/${other_user_old_experience_id_str}`)
+            .send(new_interview_experience);
+
+        assert.equal(res.status, 403);
+    });
+
+    it("should return 401, while user did not login", async () => {
+        const new_interview_experience = generateInterviewExperiencePayload();
+        delete new_interview_experience.access_token;
+
+        const res = await request(app)
+            .put(`/interview_experiences/${user_old_experience_id_str}`)
+            .send(new_interview_experience);
+
+        assert.equal(res.status, 401);
     });
 });

--- a/routes/interview_experiences/index.test.js
+++ b/routes/interview_experiences/index.test.js
@@ -915,7 +915,7 @@ describe("更新面試經驗 Interview Experience", () => {
         const history = await db.collection("experiences_history").findOne({
             ref_id: new ObjectId(user_old_experience_id_str),
         });
-        assert.deepProperty(history, "time_stamp");
+        assert.deepProperty(history, "updated_at");
         assert.deepProperty(history, "ref_id");
     });
     it("should return 403, when a user update other user`s experience", async () => {

--- a/routes/interview_experiences/index.test.js
+++ b/routes/interview_experiences/index.test.js
@@ -895,6 +895,14 @@ describe("更新面試經驗 Interview Experience", () => {
             experience.created_at.getDate(),
             user_old_experience.created_at.getDate()
         );
+
+        const old_experience = await db
+            .collection("experiences_history")
+            .findOne({
+                ref_id: new ObjectId(user_old_experience_id_str),
+            });
+        assert.deepProperty(old_experience, "time_stamp");
+        assert.deepProperty(old_experience, "ref_id");
     });
     it("should return 403, when a user update other user`s experience", async () => {
         const new_interview_experience = generateInterviewExperiencePayload({
@@ -917,5 +925,16 @@ describe("更新面試經驗 Interview Experience", () => {
             .send(new_interview_experience);
 
         assert.equal(res.status, 401);
+    });
+
+    after("DB: Clear DB collections", () => {
+        db.collection("experiences").deleteMany({});
+        db.collection("experiences_history").deleteMany({});
+    });
+
+    after("DB: 清除 companies", () => db.collection("companies").deleteMany({}));
+
+    after(() => {
+        sandbox.restore();
     });
 });

--- a/routes/work_experiences/index.js
+++ b/routes/work_experiences/index.js
@@ -16,6 +16,7 @@ const {
 } = require("../../libs/validation");
 const wrap = require("../../libs/wrap");
 const { ensureToObjectId } = require("../../models/index");
+const { experienceToHistoryMap } = require("../../models/model_maps");
 
 function validateCommonInputFields(data) {
     if (!requiredNonEmptyString(data.company_query)) {
@@ -392,10 +393,11 @@ router.put("/:id", [
             throw new HttpError("user is unauthorized", 403);
         }
 
-        old_experience.ref_id = id;
-        old_experience.time_stamp = new Date();
-        delete old_experience._id;
-        await experience_history_model.createExperienceHistory(old_experience);
+        const experience_history = experienceToHistoryMap(old_experience);
+
+        await experience_history_model.createExperienceHistory(
+            experience_history
+        );
 
         Object.assign(experience, pickupWorkExperience(req.body));
         experience.updated_at = new Date();

--- a/routes/work_experiences/index.js
+++ b/routes/work_experiences/index.js
@@ -398,16 +398,7 @@ router.put("/:id", [
         await experience_history_model.createExperienceHistory(old_experience);
 
         Object.assign(experience, pickupWorkExperience(req.body));
-        Object.assign(experience, {
-            type: "work",
-            author_id: user._id,
-            company: old_experience.company,
-            like_count: old_experience.like_count,
-            reply_count: old_experience.reply_count,
-            report_count: old_experience.report_count,
-            created_at: old_experience.created_at,
-            updated_at: new Date(),
-        });
+        experience.updated_at = new Date();
 
         const result = await experience_model.updateExperienceById(
             id,

--- a/routes/work_experiences/index.js
+++ b/routes/work_experiences/index.js
@@ -4,6 +4,7 @@ const router = express.Router();
 const HttpError = require("../../libs/errors").HttpError;
 const winston = require("winston");
 const ExperienceModel = require("../../models/experience_model");
+const ExperienceHistoryModel = require("../../models/experience_history_model");
 const helper = require("../company_helper");
 const passport = require("passport");
 const {
@@ -13,6 +14,8 @@ const {
     shouldIn,
     stringRequireLength,
 } = require("../../libs/validation");
+const wrap = require("../../libs/wrap");
+const { ensureToObjectId } = require("../../models/index");
 
 function validateCommonInputFields(data) {
     if (!requiredNonEmptyString(data.company_query)) {
@@ -339,6 +342,92 @@ router.post("/", [
                 next(err);
             });
     },
+]);
+
+/**
+ * @api {put} /work_experiences 修改工作經驗 API
+ * @apiGroup Work_Experiences
+ * @apiParam {String} company_query 公司名稱 或 統一編號
+ * @apiParam {String} [company_id] 公司統編 (如果自動完成有成功，會拿的到 company_id )
+ * @apiParam {String=
+    "彰化縣","嘉義市","嘉義縣","新竹市","新竹縣",
+    "花蓮縣","高雄市","基隆市","金門縣","連江縣",
+    "苗栗縣","南投縣","新北市","澎湖縣","屏東縣",
+    "臺中市","臺南市","臺北市","臺東縣","桃園市",
+    "宜蘭縣","雲林縣" } region 面試地區
+ * @apiParam {String} job_title 工作職稱
+ * @apiParam {Number="整數, 0 <= N <= 50"} [experience_in_year] 相關職務工作經驗
+ * @apiParam {String="大學","碩士","博士","高職","五專","二專","二技","高中","國中","國小" } [education] 最高學歷
+ * @apiParam {String="yes","no"} is_currently_employed 現在是否在職
+ * @apiParam {Object} job_ending_time 工作結束時間(當 is_currently_employed 為no時，本欄才會出現且必填)
+ * @apiParam {Number="整數, Ｎ >= current_year - 10"} job_ending_time.year 工作結束時間的年份
+ * @apiParam {Number="整數, 1~12"} job_ending_time.month 工作結束時間的月份
+ * @apiParam {Object} [salary] 薪資
+ * @apiParam {String="year","month","day","hour"} salary.type 薪資種類 (若有上傳薪資欄位，本欄必填)
+ * @apiParam {Number="整數, >= 0"} salary.amount 薪資金額 (若有上傳薪資欄位，本欄必填)
+ * @apiParam {Number="整數或浮點數。 168>=N>=0。"} [week_work_time] 一週工時
+ * @apiParam {String="yes","no"} [recommend_to_others] 是否推薦此工作
+ * @apiParam {String="0 < length <= 25 "} title 整篇經驗分享的標題
+ * @apiParam {Object[]} sections 整篇內容
+ * @apiParam {String="0 < length <= 25"} sections.subtitle 段落標題
+ * @apiParam {String="0 < length <= 5000"} sections.content 段落內容
+ * @apiParam {String="published","hidden"} [status="published"] 該篇文章的狀態
+ * @apiSuccess {Boolean} success 是否修改成功
+ */
+router.put("/:id", [
+    passport.authenticate("bearer", { session: false }),
+    wrap(async (req, res, next) => {
+        const id_str = req.params.id;
+        const user = req.user;
+
+        validationInputFields(req.body);
+
+        const experience = {};
+        const experience_model = new ExperienceModel(req.db);
+        const experience_history_model = new ExperienceHistoryModel(req.db);
+        const id = ensureToObjectId(id_str);
+        const old_experience = await experience_model.findOneOrFail(id);
+
+        if (!old_experience.author_id.equals(user._id)) {
+            throw new HttpError("user is unauthorized", 403);
+        }
+
+        old_experience.ref_id = id;
+        old_experience.time_stamp = new Date();
+        delete old_experience._id;
+        await experience_history_model.createExperienceHistory(old_experience);
+
+        Object.assign(experience, pickupWorkExperience(req.body));
+        Object.assign(experience, {
+            type: "work",
+            author_id: user._id,
+            company: (async () => {
+                const company = await helper.getCompanyByIdOrQuery(
+                    req.db,
+                    req.body.company_id,
+                    req.body.company_query
+                );
+                return company;
+            })(),
+            like_count: old_experience.like_count,
+            reply_count: old_experience.reply_count,
+            report_count: old_experience.report_count,
+            created_at: old_experience.created_at,
+            updated_at: new Date(),
+        });
+
+        const result = await experience_model.updateExperienceById(
+            id,
+            experience
+        );
+
+        res.send({
+            success: true,
+            experience: {
+                _id: result._id,
+            },
+        });
+    }),
 ]);
 
 module.exports = router;

--- a/routes/work_experiences/index.js
+++ b/routes/work_experiences/index.js
@@ -415,10 +415,7 @@ router.put("/:id", [
         );
 
         res.send({
-            success: true,
-            experience: {
-                _id: result._id,
-            },
+            success: result.ok === 1,
         });
     }),
 ]);

--- a/routes/work_experiences/index.js
+++ b/routes/work_experiences/index.js
@@ -401,14 +401,7 @@ router.put("/:id", [
         Object.assign(experience, {
             type: "work",
             author_id: user._id,
-            company: (async () => {
-                const company = await helper.getCompanyByIdOrQuery(
-                    req.db,
-                    req.body.company_id,
-                    req.body.company_query
-                );
-                return company;
-            })(),
+            company: old_experience.company,
             like_count: old_experience.like_count,
             reply_count: old_experience.reply_count,
             report_count: old_experience.report_count,

--- a/routes/work_experiences/index.test.js
+++ b/routes/work_experiences/index.test.js
@@ -762,7 +762,11 @@ describe("更新工作經驗 Work Experience", () => {
             user_old_experience.report_count
         );
         assert.deepProperty(experience, "updated_at");
-        assert.equal(experience.updated_at.getDate(), new Date().getDate());
+        assert.equal(
+            experience.updated_at.getDate(),
+            new Date().getDate(),
+            "expect updated_at equals update Date (new Date day)"
+        );
         assert.deepProperty(experience, "created_at");
         assert.equal(
             experience.created_at.getDate(),
@@ -772,7 +776,7 @@ describe("更新工作經驗 Work Experience", () => {
         const history = await db.collection("experiences_history").findOne({
             ref_id: new ObjectId(user_old_experience_id_str),
         });
-        assert.deepProperty(history, "time_stamp");
+        assert.deepProperty(history, "updated_at");
         assert.deepProperty(history, "ref_id");
     });
     it("should return 403, when a user update other user`s experience", async () => {

--- a/routes/work_experiences/index.test.js
+++ b/routes/work_experiences/index.test.js
@@ -731,7 +731,21 @@ describe("更新工作經驗 Work Experience", () => {
             _id: new ObjectId(user_old_experience_id_str),
         });
 
+        const keys = Object.keys(user_old_experience);
+        keys.forEach(value => {
+            assert.deepProperty(
+                experience,
+                value,
+                "Checking the new experience field equal old experience"
+            );
+        });
+
         assert.deepPropertyVal(experience, "job_title", "我被修改了");
+        assert.deepPropertyVal(
+            experience,
+            "company.id",
+            user_old_experience.company.id
+        );
         assert.deepPropertyVal(
             experience,
             "like_count",
@@ -755,13 +769,11 @@ describe("更新工作經驗 Work Experience", () => {
             user_old_experience.created_at.getDate()
         );
 
-        const old_experience = await db
-            .collection("experiences_history")
-            .findOne({
-                ref_id: new ObjectId(user_old_experience_id_str),
-            });
-        assert.deepProperty(old_experience, "time_stamp");
-        assert.deepProperty(old_experience, "ref_id");
+        const history = await db.collection("experiences_history").findOne({
+            ref_id: new ObjectId(user_old_experience_id_str),
+        });
+        assert.deepProperty(history, "time_stamp");
+        assert.deepProperty(history, "ref_id");
     });
     it("should return 403, when a user update other user`s experience", async () => {
         const new_work_experience = generateWorkExperiencePayload({


### PR DESCRIPTION
#457 
本次修改 : 

1. 新增兩個 API  : 
```
PUT /work_experiences/:id

PUT/interview_experiences/:id
```
2. 新增 api 的測試。

P.S 未新增驗證欄位測試，因為都是用同一個 `validationInputFields` ，這在 post 時都測試過了 (可以的話，可能的話我會將 validationInputFields 獨立出來寫個測試 )