### PR TITLE
更新 Facebook API to v3.0

### DIFF
--- a/libs/facebook.js
+++ b/libs/facebook.js
@@ -20,7 +20,7 @@ function accessTokenAuth(access_token) {
 
         request.get(
             {
-                url: "https://graph.facebook.com/v2.6/me",
+                url: "https://graph.facebook.com/v3.0/me",
                 qs: {
                     access_token,
                     fields: "id,name",

--- a/libs/facebook.test.js
+++ b/libs/facebook.test.js
@@ -16,7 +16,7 @@ describe("libs/facebook.js", () => {
             const response = { error: "error" };
 
             nock("https://graph.facebook.com:443")
-                .get("/v2.6/me")
+                .get("/v3.0/me")
                 .query({
                     access_token,
                     fields: "id,name",
@@ -31,7 +31,7 @@ describe("libs/facebook.js", () => {
             const response = { id: "-1", name: "test" };
 
             nock("https://graph.facebook.com:443")
-                .get("/v2.6/me")
+                .get("/v3.0/me")
                 .query({
                     access_token,
                     fields: "id,name",


### PR DESCRIPTION
Close #480

有經過實際測試，v3.0 的 API 在 /me 回傳的結果與 v2.6 一樣