### PR TITLE
Migrate auth (partial)

### DIFF
--- a/routes/experiences/index.js
+++ b/routes/experiences/index.js
@@ -8,12 +8,13 @@ const { ensureToObjectId } = require("../../models");
 const ExperienceModel = require("../../models/experience_model");
 const ExperienceLikeModel = require("../../models/experience_like_model");
 const {
+    requireUserAuthetication,
+} = require("../../middlewares/authentication");
+const {
     requiredNumberInRange,
     requiredNumberGreaterThanOrEqualTo,
     shouldIn,
 } = require("../../libs/validation");
-const passport = require("passport");
-const { semiAuthentication } = require("../../middlewares/authentication");
 const wrap = require("../../libs/wrap");
 const { experiencesView } = require("../../view_models/get_experiences");
 const { experienceView } = require("../../view_models/get_experience");
@@ -245,7 +246,6 @@ const isExperienceArchived = R.path(["archive", "is_archived"]);
  */
 /* eslint-enable */
 router.get("/:id", [
-    semiAuthentication("bearer", { session: false }),
     wrap(async (req, res) => {
         const id_str = req.params.id;
         let user = null;
@@ -294,7 +294,7 @@ function _isLegalStatus(value) {
  * @apiSuccess {String} status 更新後狀態
  */
 router.patch("/:id", [
-    passport.authenticate("bearer", { session: false }),
+    requireUserAuthetication,
     wrap(async (req, res) => {
         const id = req.params.id;
         const status = req.body.status;

--- a/routes/experiences/likes.js
+++ b/routes/experiences/likes.js
@@ -1,7 +1,9 @@
 const express = require("express");
 const winston = require("winston");
-const passport = require("passport");
 
+const {
+    requireUserAuthetication,
+} = require("../../middlewares/authentication");
 const ExperienceLikeModel = require("../../models/experience_like_model");
 const ExperienceModel = require("../../models/experience_model");
 const PopularExperienceLogsModel = require("../../models/popular_experience_logs_model");
@@ -21,7 +23,7 @@ const router = express.Router();
  * @apiSuccess {Boolean} success 是否成功點讚
  */
 router.post("/:id/likes", [
-    passport.authenticate("bearer", { session: false }),
+    requireUserAuthetication,
     wrap(async (req, res, next) => {
         const user = req.user;
         const experience_id = ensureToObjectId(req.params.id);
@@ -68,7 +70,7 @@ router.post("/:id/likes", [
  * @apiSuccess {Boolean} success 是否成功取消讚
  */
 router.delete("/:id/likes", [
-    passport.authenticate("bearer", { session: false }),
+    requireUserAuthetication,
     wrap(async (req, res, next) => {
         const user = req.user;
         const experience_id = ensureToObjectId(req.params.id);

--- a/routes/experiences/replies.js
+++ b/routes/experiences/replies.js
@@ -1,5 +1,4 @@
 const express = require("express");
-const passport = require("passport");
 const R = require("ramda");
 
 const { ensureToObjectId } = require("../../models");
@@ -7,7 +6,9 @@ const ExperienceModel = require("../../models/experience_model");
 const ReplyModel = require("../../models/reply_model");
 const ReplyLikeModel = require("../../models/reply_like_model");
 const PopularExperienceLogsModel = require("../../models/popular_experience_logs_model");
-const { semiAuthentication } = require("../../middlewares/authentication");
+const {
+    requireUserAuthetication,
+} = require("../../middlewares/authentication");
 const { HttpError } = require("../../libs/errors");
 const {
     requiredNumberInRange,
@@ -43,7 +44,7 @@ function validationPostFields(body) {
  * @apiSuccess {String} reply.created_at 該留言的時間
  */
 router.post("/:id/replies", [
-    passport.authenticate("bearer", { session: false }),
+    requireUserAuthetication,
     wrap(async (req, res) => {
         validationPostFields(req.body);
 
@@ -108,7 +109,6 @@ const repliesView = R.map(replyView);
  * @apiSuccess {Number} replies.floor 樓層
  */
 router.get("/:id/replies", [
-    semiAuthentication("bearer", { session: false }),
     wrap(async (req, res) => {
         const experience_id_string = req.params.id;
         const limit = parseInt(req.query.limit, 10) || 20;

--- a/routes/experiences/reports.js
+++ b/routes/experiences/reports.js
@@ -1,5 +1,4 @@
 const express = require("express");
-const passport = require("passport");
 const R = require("ramda");
 const { HttpError } = require("../../libs/errors");
 
@@ -14,6 +13,9 @@ const {
     stringRequireLength,
     shouldIn,
 } = require("../../libs/validation");
+const {
+    requireUserAuthetication,
+} = require("../../middlewares/authentication");
 
 function validatePostFields(body) {
     if (
@@ -53,7 +55,7 @@ const reportsView = R.map(reportView);
  */
 /* eslint-enable */
 router.post("/:id/reports", [
-    passport.authenticate("bearer", { session: false }),
+    requireUserAuthetication,
     wrap(async (req, res) => {
         validatePostFields(req.body);
 

--- a/routes/interview_experiences/index.js
+++ b/routes/interview_experiences/index.js
@@ -5,7 +5,6 @@ const HttpError = require("../../libs/errors").HttpError;
 const winston = require("winston");
 const ExperienceModel = require("../../models/experience_model");
 const helper = require("../company_helper");
-const passport = require("passport");
 const {
     requiredNonEmptyString,
     requiredNumber,
@@ -14,6 +13,9 @@ const {
     stringRequireLength,
 } = require("../../libs/validation");
 const wrap = require("../../libs/wrap");
+const {
+    requireUserAuthetication,
+} = require("../../middlewares/authentication");
 
 function validateCommonInputFields(data) {
     if (!requiredNonEmptyString(data.company_query)) {
@@ -316,7 +318,7 @@ function validationInputFields(data) {
  * @apiSuccess {String} experience._id 經驗分享id
  */
 router.post("/", [
-    passport.authenticate("bearer", { session: false }),
+    requireUserAuthetication,
     wrap(async (req, res) => {
         validationInputFields(req.body);
 


### PR DESCRIPTION
將 /experiences API, /interview_experiences API 換成 Token auth，測試也改成 JWT based

(由於本來想 mock passport 的 authentication 段，但找不到方法，所以只好 end-to-end 建 user，發 token)
