### PR TITLE
串接 AWS SES Email service

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -4,4 +4,5 @@ module.exports = {
     REDIS_URL: process.env.REDIS_URL || "redis://localhost",
     CORS_ANY: process.env.CORS_ANY || "FALSE",
     JWT_SECRET: process.env.JWT_SECRET,
+    AWS_SES_SERVER_REGION: process.env.AWS_SES_SERVER_REGION || "us-west-2",
 };

--- a/libs/email.js
+++ b/libs/email.js
@@ -1,0 +1,68 @@
+/*
+    Before loading AWS SDK, please ensure you have correct
+    `AWS_ACCESS_KEY_ID` & `AWS_SECRET_ACCESS_KEY` environment
+    variables, and having corresponding permission to send email
+*/
+
+const AWS = require("aws-sdk");
+const config = require("config");
+
+// Set the region and API version
+AWS.config.update({ region: config.get("AWS_SES_SERVER_REGION") });
+const SES = new AWS.SES({ apiVersion: "2010-12-01" });
+
+/* prepare constants */
+// friendly from name （收到信的時候，來信者的名字）
+const fromName = "職場透明化運動 GoodJob";
+// 因為 AWS 只支援 ASCII character 作為 from name，這邊要做一些編碼轉換
+// reference: https://github.com/aws/aws-sdk-js/issues/1585
+const base64FromName = Buffer.from(fromName).toString("base64");
+// this email domain must be verified by AWS
+const fromEmail = "noreply@email.goodjob.life";
+
+/**
+ *
+ * @param {*} toAddresses 目標對象的電子郵件列表
+ * @param {*} bodyHTML 內容的 html 字串 （UTF-8）
+ * @param {*} subject 標題字串 （UTF-8）
+ */
+const sendEmail = async (toAddresses, bodyHTML, subject) => {
+    const params = {
+        Destination: {
+            /* required */
+            // CcAddresses: [],
+            ToAddresses: toAddresses,
+        },
+        Message: {
+            /* required */
+            Body: {
+                /* required */
+                Html: {
+                    Charset: "UTF-8",
+                    Data: bodyHTML,
+                },
+            },
+            Subject: {
+                Charset: "UTF-8",
+                Data: subject,
+            },
+        },
+        Source: `=?UTF-8?B?${base64FromName}?= <${fromEmail}>` /* required */,
+        // ReplyToAddresses: [],
+    };
+    return SES.sendEmail(params).promise();
+};
+
+/* example to handle promise's fulfilled/rejected states
+    sendPromise.then(
+        function(data) {
+        console.log(data.MessageId);
+    }).catch(
+        function(err) {
+        console.error(err, err.stack);
+    });
+*/
+
+module.exports = {
+    sendEmail,
+};

--- a/libs/email.js
+++ b/libs/email.js
@@ -82,25 +82,11 @@ const sendEmailsFromTemplate = async (toAddresses, templateName, variables) => {
     // validate variables
     template.validateVariables(variables);
 
-    const params = {
-        Destination: {
-            ToAddresses: toAddresses,
-        },
-        Message: {
-            Body: {
-                Html: {
-                    Charset: "UTF-8",
-                    Data: template.genBodyHTML(variables),
-                },
-            },
-            Subject: {
-                Charset: "UTF-8",
-                Data: template.genSubject(variables),
-            },
-        },
-        Source: `=?UTF-8?B?${base64FromName}?= <${fromEmail}>`,
-    };
-    return SES.sendEmail(params).promise();
+    return sendEmails(
+        toAddresses,
+        template.genBodyHTML(variables),
+        template.genSubject(variables)
+    );
 };
 
 /** sample code use sendEmailsFromTemplate

--- a/libs/email.js
+++ b/libs/email.js
@@ -55,16 +55,6 @@ const sendEmails = async (toAddresses, bodyHTML, subject) => {
     return SES.sendEmail(params).promise();
 };
 
-/** sample code to send same emails to different destination
-(async () => {
-    await sendEmails(
-        ["barry800414@gmail.com"],
-        "<p>this is an test email</p>",
-        "這是一封測試郵件"
-    );
-})();
-*/
-
 /**
  * 寄送一封樣板信件到不同的電子郵件地址（內容相同）
  * @param {String[]} toAddresses 目標對象的電子郵件列表
@@ -88,19 +78,6 @@ const sendEmailsFromTemplate = async (toAddresses, templateName, variables) => {
         template.genSubject(variables)
     );
 };
-
-/** sample code use sendEmailsFromTemplate
-(async () => {
-    const { EMAIL_TEMPLATE_NAMES } = require("./email_templates");
-    await sendEmailsFromTemplate(
-        ["barry800414@gmail.com"],
-        EMAIL_TEMPLATE_NAMES.ACCOUNT_VERIFY_SUCCESS,
-        {
-            username: "Wei-Ming",
-            verifyUrl: "http://localhost:3000/verify?token=ooxx",
-        }
-    );
-})();*/
 
 module.exports = {
     sendEmails,

--- a/libs/email.js
+++ b/libs/email.js
@@ -77,7 +77,7 @@ const sendEmailsFromTemplate = async (toAddresses, templateName, variables) => {
             `Email template ${templateName} not found`
         );
     }
-    const template = EMAIL_TEMPLATES[templateName];
+    const template = new EMAIL_TEMPLATES[templateName]();
 
     // validate variables
     template.validateVariables(variables);
@@ -114,8 +114,7 @@ const sendEmailsFromTemplate = async (toAddresses, templateName, variables) => {
             verifyUrl: "http://localhost:3000/verify?token=ooxx",
         }
     );
-})();
-*/
+})();*/
 
 module.exports = {
     sendEmails,

--- a/libs/email.js
+++ b/libs/email.js
@@ -21,22 +21,21 @@ const base64FromName = Buffer.from(fromName).toString("base64");
 const fromEmail = "noreply@email.goodjob.life";
 
 /**
+ * 寄送一封信件到不同的電子郵件地址（內容相同）
+ * @param {String[]} toAddresses 目標對象的電子郵件列表
+ * @param {String} bodyHTML 內容的 html 字串 （UTF-8）
+ * @param {String} subject 標題字串 （UTF-8）
  *
- * @param {*} toAddresses 目標對象的電子郵件列表
- * @param {*} bodyHTML 內容的 html 字串 （UTF-8）
- * @param {*} subject 標題字串 （UTF-8）
+ * @fulfilled data success response
+ * @rejected error
  */
-const sendEmail = async (toAddresses, bodyHTML, subject) => {
+const sendEmails = async (toAddresses, bodyHTML, subject) => {
     const params = {
         Destination: {
-            /* required */
-            // CcAddresses: [],
             ToAddresses: toAddresses,
         },
         Message: {
-            /* required */
             Body: {
-                /* required */
                 Html: {
                     Charset: "UTF-8",
                     Data: bodyHTML,
@@ -47,22 +46,21 @@ const sendEmail = async (toAddresses, bodyHTML, subject) => {
                 Data: subject,
             },
         },
-        Source: `=?UTF-8?B?${base64FromName}?= <${fromEmail}>` /* required */,
-        // ReplyToAddresses: [],
+        Source: `=?UTF-8?B?${base64FromName}?= <${fromEmail}>`,
     };
     return SES.sendEmail(params).promise();
 };
 
-/* example to handle promise's fulfilled/rejected states
-    sendPromise.then(
-        function(data) {
-        console.log(data.MessageId);
-    }).catch(
-        function(err) {
-        console.error(err, err.stack);
-    });
+/** sample code to send same emails to different destination
+(async () => {
+    await sendEmails(
+        ["barry800414@gmail.com"],
+        "<p>this is an test email</p>",
+        "這是一封測試郵件"
+    );
+})();
 */
 
 module.exports = {
-    sendEmail,
+    sendEmails,
 };

--- a/libs/email.js
+++ b/libs/email.js
@@ -6,7 +6,8 @@
 
 const AWS = require("aws-sdk");
 const config = require("config");
-const { EmailTemplateNotFoundError } = require("./errors");
+const { EmailTemplateTypeError } = require("./errors");
+const EmailTemplate = require("./email_templates/template");
 
 // Set the region and API version
 AWS.config.update({ region: config.get("AWS_SES_SERVER_REGION") });
@@ -20,9 +21,6 @@ const fromName = "職場透明化運動 GoodJob";
 const base64FromName = Buffer.from(fromName).toString("base64");
 // this email domain must be verified by AWS
 const fromEmail = "noreply@email.goodjob.life";
-
-// load email templates
-const { EMAIL_TEMPLATES } = require("./email_templates");
 
 /**
  * 寄送一封信件到不同的電子郵件地址（內容相同）
@@ -58,16 +56,15 @@ const sendEmails = async (toAddresses, bodyHTML, subject) => {
 /**
  * 寄送一封樣板信件到不同的電子郵件地址（內容相同）
  * @param {String[]} toAddresses 目標對象的電子郵件列表
- * @param {String} templateName 樣板名稱
+ * @param {Object} template Email 樣板物件（EmailTemplate Class 的實體）
  * @param {Object} variables 變數物件
  */
-const sendEmailsFromTemplate = async (toAddresses, templateName, variables) => {
-    if (!EMAIL_TEMPLATES[templateName]) {
-        throw new EmailTemplateNotFoundError(
-            `Email template ${templateName} not found`
+const sendEmailsFromTemplate = async (toAddresses, template, variables) => {
+    if (!(template instanceof EmailTemplate)) {
+        throw new EmailTemplateTypeError(
+            "template is not an instanceof EmailTemplate"
         );
     }
-    const template = new EMAIL_TEMPLATES[templateName]();
 
     // validate variables
     template.validateVariables(variables);

--- a/libs/email_templates/account_verify.js
+++ b/libs/email_templates/account_verify.js
@@ -12,7 +12,7 @@ const schema = Joi.object().keys({
         .required(),
 });
 
-class VerifySuccessTemplate extends EmailTemplate {
+class AccountVerifyTemplate extends EmailTemplate {
     validateVariables(variables) {
         const result = Joi.validate(variables, schema);
         if (result.error === null) {
@@ -31,4 +31,4 @@ class VerifySuccessTemplate extends EmailTemplate {
     }
 }
 
-module.exports = VerifySuccessTemplate;
+module.exports = AccountVerifyTemplate;

--- a/libs/email_templates/index.js
+++ b/libs/email_templates/index.js
@@ -1,0 +1,14 @@
+const EMAIL_TEMPLATES = {
+    ACCOUNT_VERIFY_SUCCESS: require("./verify_success"),
+};
+
+// just for converting to { AAA: 'AAA', BBB: 'BBB' } format
+const EMAIL_TEMPLATE_NAMES = Object.keys(EMAIL_TEMPLATES).reduce((acc, cur) => {
+    acc[cur] = cur;
+    return acc;
+}, {});
+
+module.exports = {
+    EMAIL_TEMPLATES,
+    EMAIL_TEMPLATE_NAMES,
+};

--- a/libs/email_templates/index.js
+++ b/libs/email_templates/index.js
@@ -1,14 +1,5 @@
-const EMAIL_TEMPLATES = {
-    ACCOUNT_VERIFY_SUCCESS: require("./verify_success"),
-};
-
-// just for converting to { AAA: 'AAA', BBB: 'BBB' } format
-const EMAIL_TEMPLATE_NAMES = Object.keys(EMAIL_TEMPLATES).reduce((acc, cur) => {
-    acc[cur] = cur;
-    return acc;
-}, {});
+const VerifySuccessTemplate = require("./verify_success");
 
 module.exports = {
-    EMAIL_TEMPLATES,
-    EMAIL_TEMPLATE_NAMES,
+    VerifySuccessTemplate,
 };

--- a/libs/email_templates/index.js
+++ b/libs/email_templates/index.js
@@ -1,5 +1,5 @@
-const VerifySuccessTemplate = require("./verify_success");
+const AccountVerifyTemplate = require("./account_verify");
 
 module.exports = {
-    VerifySuccessTemplate,
+    AccountVerifyTemplate,
 };

--- a/libs/email_templates/template.js
+++ b/libs/email_templates/template.js
@@ -1,0 +1,8 @@
+class EmailTemplate {
+    constructor() {}
+    validateVariables() {}
+    genBodyHTML() {}
+    genSubject() {}
+}
+
+module.exports = EmailTemplate;

--- a/libs/email_templates/verify_success.js
+++ b/libs/email_templates/verify_success.js
@@ -1,0 +1,39 @@
+const Joi = require("joi");
+const { EmailTemplateVariablesError } = require("../errors");
+
+const schema = Joi.object().keys({
+    username: Joi.string()
+        .min(1)
+        .max(30)
+        .required(),
+    verifyUrl: Joi.string()
+        .uri()
+        .required(),
+});
+
+const validateVariables = variables => {
+    const result = Joi.validate(variables, schema);
+    if (result.error === null) {
+        return true;
+    } else {
+        throw new EmailTemplateVariablesError(result.error);
+    }
+};
+
+const genBodyHTML = variables => {
+    return `<div>${
+        variables.username
+    } 感謝您註冊職場透明化運動，點擊以下按鈕，馬上驗證您的信箱<a href="${
+        variables.verifyUrl
+    }">驗證</a></div>`;
+};
+
+const genSubject = () => {
+    return "職場透明化運動電子信箱驗證信";
+};
+
+module.exports = {
+    validateVariables,
+    genBodyHTML,
+    genSubject,
+};

--- a/libs/email_templates/verify_success.js
+++ b/libs/email_templates/verify_success.js
@@ -1,4 +1,5 @@
 const Joi = require("joi");
+const EmailTemplate = require("./template");
 const { EmailTemplateVariablesError } = require("../errors");
 
 const schema = Joi.object().keys({
@@ -11,29 +12,27 @@ const schema = Joi.object().keys({
         .required(),
 });
 
-const validateVariables = variables => {
-    const result = Joi.validate(variables, schema);
-    if (result.error === null) {
-        return true;
-    } else {
-        throw new EmailTemplateVariablesError(result.error);
+class VerifySuccessTemplate extends EmailTemplate {
+    constructor() {
+        super();
     }
-};
 
-const genBodyHTML = variables => {
-    return `<div>${
-        variables.username
-    } 感謝您註冊職場透明化運動，點擊以下按鈕，馬上驗證您的信箱<a href="${
-        variables.verifyUrl
-    }">驗證</a></div>`;
-};
+    validateVariables(variables) {
+        const result = Joi.validate(variables, schema);
+        if (result.error === null) {
+            return true;
+        } else {
+            throw new EmailTemplateVariablesError(result.error);
+        }
+    }
 
-const genSubject = () => {
-    return "職場透明化運動電子信箱驗證信";
-};
+    genBodyHTML({ username, verifyUrl }) {
+        return `<div>${username} 感謝您註冊職場透明化運動，點擊以下按鈕，馬上驗證您的信箱<a href="${verifyUrl}">驗證</a></div>`;
+    }
 
-module.exports = {
-    validateVariables,
-    genBodyHTML,
-    genSubject,
-};
+    genSubject() {
+        return "職場透明化運動電子信箱驗證信";
+    }
+}
+
+module.exports = VerifySuccessTemplate;

--- a/libs/email_templates/verify_success.js
+++ b/libs/email_templates/verify_success.js
@@ -13,10 +13,6 @@ const schema = Joi.object().keys({
 });
 
 class VerifySuccessTemplate extends EmailTemplate {
-    constructor() {
-        super();
-    }
-
     validateVariables(variables) {
         const result = Joi.validate(variables, schema);
         if (result.error === null) {

--- a/libs/errors.js
+++ b/libs/errors.js
@@ -27,7 +27,7 @@ class ObjectNotExistError extends Error {
      */
 }
 
-class EmailTemplateNotFoundError extends Error {
+class EmailTemplateTypeError extends Error {
     /*
      * @param  message  any
      */
@@ -43,5 +43,5 @@ module.exports.HttpError = HttpError;
 module.exports.ObjectIdError = ObjectIdError;
 module.exports.DuplicateKeyError = DuplicateKeyError;
 module.exports.ObjectNotExistError = ObjectNotExistError;
-module.exports.EmailTemplateNotFoundError = EmailTemplateNotFoundError;
+module.exports.EmailTemplateTypeError = EmailTemplateTypeError;
 module.exports.EmailTemplateVariablesError = EmailTemplateVariablesError;

--- a/libs/errors.js
+++ b/libs/errors.js
@@ -27,7 +27,21 @@ class ObjectNotExistError extends Error {
      */
 }
 
+class EmailTemplateNotFoundError extends Error {
+    /*
+     * @param  message  any
+     */
+}
+
+class EmailTemplateVariablesError extends Error {
+    /*
+     * @param  message  any
+     */
+}
+
 module.exports.HttpError = HttpError;
 module.exports.ObjectIdError = ObjectIdError;
 module.exports.DuplicateKeyError = DuplicateKeyError;
 module.exports.ObjectNotExistError = ObjectNotExistError;
+module.exports.EmailTemplateNotFoundError = EmailTemplateNotFoundError;
+module.exports.EmailTemplateVariablesError = EmailTemplateVariablesError;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "apollo-server-express": "^2.4.0",
+    "aws-sdk": "^2.387.0",
     "body-parser": "^1.15.1",
     "compression": "^1.6.2",
     "config": "^1.25.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "graphql": "^14.1.1",
     "graphql-resolvers": "^0.3.2",
     "jsonwebtoken": "^8.4.0",
+    "joi": "^14.3.1",
     "lodash": "^4.13.1",
     "mongodb": "^3.1.1",
     "morgan": "^1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2161,6 +2161,11 @@ hoek@2.x.x:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
   integrity sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=
 
+hoek@6.x.x:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-6.1.2.tgz#99e6d070561839de74ee427b61aa476bd6bddfd6"
+  integrity sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q==
+
 http-errors@1.6.3, http-errors@~1.6.3:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
@@ -2599,6 +2604,13 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
+isemail@3.x.x:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/isemail/-/isemail-3.2.0.tgz#59310a021931a9fb06bbb51e155ce0b3f236832c"
+  integrity sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==
+  dependencies:
+    punycode "2.x.x"
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -2657,6 +2669,15 @@ jodid25519@^1.0.0:
   integrity sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=
   dependencies:
     jsbn "~0.1.0"
+
+joi@^14.3.1:
+  version "14.3.1"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-14.3.1.tgz#164a262ec0b855466e0c35eea2a885ae8b6c703c"
+  integrity sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==
+  dependencies:
+    hoek "6.x.x"
+    isemail "3.x.x"
+    topo "3.x.x"
 
 js-tokens@^3.0.2:
   version "3.0.2"
@@ -3835,6 +3856,11 @@ punycode@1.3.2:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
   integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
 
+punycode@2.x.x:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -4687,6 +4713,13 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+
+topo@3.x.x:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/topo/-/topo-3.0.3.tgz#d5a67fb2e69307ebeeb08402ec2a2a6f5f7ad95c"
+  integrity sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==
+  dependencies:
+    hoek "6.x.x"
 
 touch@^3.1.0:
   version "3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -534,6 +534,21 @@ atob@^2.0.0:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.0.tgz#ab2b150e51d7b122b9efc8d7340c06b6c41076bc"
   integrity sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw==
 
+aws-sdk@^2.387.0:
+  version "2.387.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.387.0.tgz#c4b95c280e8b737a30df37928aa18a892eaedb8a"
+  integrity sha512-GSJwNBqdDDqRpTBNnSlAVeQ4wqIiWIhqsnvE0GcGmVQWDq7yM89EiYqkIcB8dFV/l6bm7f0TFDtEbIwoRP6C4w==
+  dependencies:
+    buffer "4.9.1"
+    events "1.1.1"
+    ieee754 "1.1.8"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
 aws-sign2@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
@@ -562,6 +577,11 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+
+base64-js@^1.0.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
+  integrity sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==
 
 base@^0.11.1:
   version "0.11.2"
@@ -688,6 +708,15 @@ buffer-shims@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
   integrity sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=
+
+buffer@4.9.1:
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
+  integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
 
 busboy@^0.3.0:
   version "0.3.0"
@@ -1545,6 +1574,11 @@ eventemitter3@^3.1.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
   integrity sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==
 
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
+
 execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
@@ -2195,6 +2229,16 @@ iconv-lite@^0.4.17:
   dependencies:
     safer-buffer "^2.1.0"
 
+ieee754@1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
+  integrity sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=
+
+ieee754@^1.1.4:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"
+  integrity sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==
+
 ignore-by-default@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
@@ -2550,7 +2594,7 @@ isarray@0.0.1:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
   integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
-isarray@1.0.0, isarray@~1.0.0:
+isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
@@ -2601,6 +2645,11 @@ jest-validate@^23.0.0:
     jest-get-type "^22.1.0"
     leven "^2.1.0"
     pretty-format "^23.2.0"
+
+jmespath@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
+  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
 jodid25519@^1.0.0:
   version "1.0.2"
@@ -3781,6 +3830,11 @@ pstree.remy@^1.1.0:
   dependencies:
     ps-tree "^1.1.0"
 
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -3800,6 +3854,11 @@ qs@6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 ramda@^0.25.0:
   version "0.25.0"
@@ -4102,7 +4161,12 @@ saslprep@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/saslprep/-/saslprep-1.0.0.tgz#2c4968a0bfbf249530cd597bc62870ccd4b41a24"
 
-sax@^1.2.4:
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
+sax@>=0.6.0, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -4775,6 +4839,14 @@ url-parse-lax@^1.0.0:
   dependencies:
     prepend-http "^1.0.1"
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 use@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.0.tgz#14716bf03fdfefd03040aef58d8b4b85f3a7c544"
@@ -4800,15 +4872,15 @@ utils-merge@1.0.0:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
   integrity sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=
 
+uuid@3.3.2, uuid@^3.1.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+
 uuid@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
   integrity sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=
-
-uuid@^3.1.0:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
-  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 vary@^1, vary@~1.1.0:
   version "1.1.1"
@@ -4899,6 +4971,19 @@ xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
   integrity sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=
+
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 yallist@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
Close #512 

## 這個 PR 是？ <!-- 必填 -->

1. 串接 AWS SDK 中的 Simple Email Service (SES)  API
2. 提供兩個 service 街口 (`sendEmails` & `sendEmailsFromTemplate` ）以寄送電子信箱
3. `sendEmails` 用途是給定 subject 和 html body，寄送一樣的內容到不同的信箱位置
4. `sendEmailsFromTemplates` 用途是給定 templateName 和 variables，寄送一樣的內容到不同的信箱位置

## 我應該從何看起？  <!-- 選填，沒有就刪掉 -->

by commit 

其中日後 email template 裡面必須包含三個函數
- `validateVariables`：驗證變數是否正確
- `genBodyHtml`：產生 html body
- `genSubject`：產生標題

## 若可以手動測試，要如何測試？ <!-- 選填 -->

- [ ] 跟我要 `AWS_ACCESS_KEY_ID` & `AWS_SECRET_ACCESS_KEY`
- [ ] 給我你的 email ，我加入到 sandbox email 列表 （彥齊不用）
- [ ] 把 ./libs/email.js 註解的 sample code 解除註解，換個參數，嘗試寄信到自己的信箱
