### PR TITLE
bugfix: resolve employment type part-time and dispatched-labor correctly

### DIFF
--- a/schema/salary_work_time.js
+++ b/schema/salary_work_time.js
@@ -100,6 +100,8 @@ const resolvers = {
     },
     EmploymentType: {
         full_time: "full-time",
+        part_time: "part-time",
+        dispatched_labor: "dispatched-labor",
     },
     SalaryWorkTime: {
         id: salaryWorkTime => {


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

employment type 在解析 part-time & dispatched-labor 的時候會錯掉，這個 PR 修正之

## 若可以手動測試，要如何測試？ <!-- 選填 -->

- [ ] 留一筆兼職或派遣的薪資工時，graphql API 打打看，應該不能錯誤
