### PR TITLE
Feat/experience type fix and experience(id) resolver

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1,3 +1,8 @@
+type Archive {
+  is_archived: Boolean!
+  reason: String!
+}
+
 type Company {
   name: String!
 
@@ -13,16 +18,6 @@ type Company {
 }
 
 scalar Date
-
-enum Education {
-  """TOFIX"""
-  bachelor
-  master
-  doctor
-  senior_high
-  junior_high
-  primary
-}
 
 enum EmailStatus {
   UNVERIFIED
@@ -46,7 +41,7 @@ interface Experience {
   job_title: JobTitle!
   region: String!
   experience_in_year: Int
-  education: Education
+  education: String
   salary: Salary
   title: String
   sections: [Section]!
@@ -54,12 +49,14 @@ interface Experience {
   reply_count: Int!
   report_count: Int!
   like_count: Int!
+  status: PublishStatus!
+  archive: Archive!
 }
 
 enum ExperienceType {
-  WORK
-  INTERVIEW
-  INTERN
+  work
+  interview
+  intern
 }
 
 enum Gender {
@@ -75,7 +72,7 @@ type InterviewExperience implements Experience {
   job_title: JobTitle!
   region: String!
   experience_in_year: Int
-  education: Education
+  education: String
   salary: Salary
   title: String
   sections: [Section]!
@@ -83,6 +80,8 @@ type InterviewExperience implements Experience {
   reply_count: Int!
   report_count: Int!
   like_count: Int!
+  status: PublishStatus!
+  archive: Archive!
 
   """interview experience specific fields"""
   interview_time: YearMonth!
@@ -125,6 +124,12 @@ enum Order {
   ASCENDING
 }
 
+"""發布狀態"""
+enum PublishStatus {
+  published
+  hidden
+}
+
 type Query {
   placeholder: Boolean
   salary_work_time_count: Int!
@@ -143,6 +148,22 @@ type Query {
 
   """取得薪資工時列表 （未下關鍵字搜尋的情況），只有從最新排到最舊"""
   salary_work_times: [SalaryWorkTime]!
+}
+
+type Reply {
+  id: ID!
+  content: String!
+  like_count: Int!
+  report_count: Int!
+  floor: Int!
+  created_at: Date!
+  status: PublishStatus!
+
+  """相對應的 experience (resolve if published)"""
+  experience: Experience
+
+  """使用者是否按贊 (null 代表未傳入驗證資訊)"""
+  liked: Boolean
 }
 
 type Salary {
@@ -206,6 +227,18 @@ type User {
   email: String
   email_status: EmailStatus
   created_at: Date!
+
+  """The user's experiences"""
+  experiences(start: Int = 0, limit: Int = 20): [Experience!]!
+  experience_count: Int!
+
+  """The user's replies"""
+  replies(start: Int = 0, limit: Int = 20): [Reply!]!
+  reply_count: Int!
+
+  """The user's salary_work_time"""
+  salary_work_times: [SalaryWorkTime!]!
+  salary_work_time_count: Int!
 }
 
 type WorkExperience implements Experience {
@@ -215,7 +248,7 @@ type WorkExperience implements Experience {
   job_title: JobTitle!
   region: String!
   experience_in_year: Int
-  education: Education
+  education: String
   salary: Salary
   title: String
   sections: [Section]!
@@ -223,11 +256,13 @@ type WorkExperience implements Experience {
   reply_count: Int!
   report_count: Int!
   like_count: Int!
+  status: PublishStatus!
+  archive: Archive!
 
   """work experience specific fields"""
   data_time: YearMonth
   week_work_time: Int
-  recommend_to_others: Boolean
+  recommend_to_others: String
 }
 
 type WorkExperienceStatistics {

--- a/schema/experience.js
+++ b/schema/experience.js
@@ -1,4 +1,5 @@
 const { gql } = require("apollo-server-express");
+const ObjectId = require("mongodb").ObjectId;
 
 const WorkExperienceType = "work";
 const InterviewExperienceType = "interview";
@@ -132,6 +133,20 @@ const resolvers = {
     },
     InterviewExperience: {
         id: experience => experience._id,
+    },
+
+    Query: {
+        async experience(_, { id }, ctx) {
+            const collection = ctx.db.collection("experiences");
+
+            const result = await collection.findOne({ _id: ObjectId(id) });
+
+            if (!result) {
+                return null;
+            } else {
+                return result;
+            }
+        },
     },
 };
 

--- a/schema/experience.js
+++ b/schema/experience.js
@@ -12,7 +12,7 @@ const Type = gql`
         job_title: JobTitle!
         region: String!
         experience_in_year: Int
-        education: Education
+        education: String
         salary: Salary
         title: String
         sections: [Section]!
@@ -31,7 +31,7 @@ const Type = gql`
         job_title: JobTitle!
         region: String!
         experience_in_year: Int
-        education: Education
+        education: String
         salary: Salary
         title: String
         sections: [Section]!
@@ -60,7 +60,7 @@ const Type = gql`
         job_title: JobTitle!
         region: String!
         experience_in_year: Int
-        education: Education
+        education: String
         salary: Salary
         title: String
         sections: [Section]!
@@ -85,19 +85,9 @@ const Type = gql`
     }
 
     enum ExperienceType {
-        WORK
-        INTERVIEW
-        INTERN
-    }
-
-    enum Education {
-        "TOFIX"
-        bachelor
-        master
-        doctor
-        senior_high
-        junior_high
-        primary
+        work
+        interview
+        intern
     }
 
     type Section {
@@ -136,10 +126,6 @@ const resolvers = {
             }
             return null;
         },
-    },
-    ExperienceType: {
-        WORK: WorkExperienceType,
-        INTERVIEW: InterviewExperienceType,
     },
     WorkExperience: {
         id: experience => experience._id,

--- a/schema/experience.js
+++ b/schema/experience.js
@@ -138,7 +138,11 @@ const resolvers = {
         async experience(_, { id }, ctx) {
             const collection = ctx.db.collection("experiences");
 
-            const result = await collection.findOne({ _id: ObjectId(id) });
+            const result = await collection.findOne({
+                _id: ObjectId(id),
+                status: "published",
+                "archive.is_archived": false,
+            });
 
             if (!result) {
                 return null;

--- a/schema/experience.js
+++ b/schema/experience.js
@@ -134,7 +134,6 @@ const resolvers = {
     InterviewExperience: {
         id: experience => experience._id,
     },
-
     Query: {
         async experience(_, { id }, ctx) {
             const collection = ctx.db.collection("experiences");


### PR DESCRIPTION
Close #  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

1. Type Education 因為會有中文，決定直接改成 String type
2. Enum ExperienceType 直接改成小寫，跟 DB 存的常數一樣，就不用寫 resolver
3. 寫 query { experience(id) } 的 resolver  

## 我應該從何看起？  <!-- 選填，沒有就刪掉 -->

by commit 

## 若可以手動測試，要如何測試？ <!-- 選填 -->

- [ ] open http://localhost:12000/graphql
- [ ] 測下面這個 query

```graphql
{
  experience(id: "some id"){
    id
    title
    education
    type
  }  
}
```
應該要正常

### 其他
- query { experiences } ，也就是經驗分享的列表 API 暫時不做，因為改版之後會把面試 / 工作的直接切開，到時候需求明確一點的時候再做