### PR TITLE
Feat: add query { salary_work_times } resolver

### DIFF
--- a/schema/salary_work_time.js
+++ b/schema/salary_work_time.js
@@ -1,4 +1,9 @@
-const { gql } = require("apollo-server-express");
+const { gql, UserInputError } = require("apollo-server-express");
+const WorkingModel = require("../models/working_model");
+const {
+    requiredNumberInRange,
+    requiredNumberGreaterThanOrEqualTo,
+} = require("../libs/validation");
 
 const Type = gql`
     type SalaryWorkTime {
@@ -91,7 +96,7 @@ const Type = gql`
 const Query = gql`
     extend type Query {
         "取得薪資工時列表 （未下關鍵字搜尋的情況），只有從最新排到最舊"
-        salary_work_times: [SalaryWorkTime]!
+        salary_work_times(start: Int!, limit: Int!): [SalaryWorkTime]!
     }
 `;
 
@@ -115,6 +120,34 @@ const resolvers = {
             return {
                 name: salaryWorkTime.job_title,
             };
+        },
+    },
+    Query: {
+        async salary_work_times(_, { start, limit }, { db }) {
+            if (!requiredNumberGreaterThanOrEqualTo(start, 0)) {
+                throw new UserInputError("start 格式錯誤");
+            }
+            if (!requiredNumberInRange(limit, 1, 100)) {
+                throw new UserInputError("limit 格式錯誤");
+            }
+
+            const sort = {
+                created_at: -1,
+            };
+
+            const query = {
+                status: "published",
+                "archive.is_archived": false,
+            };
+
+            const salary_work_time_model = new WorkingModel(db);
+            const salary_work_times = await salary_work_time_model.getWorkings(
+                query,
+                sort,
+                start,
+                limit
+            );
+            return salary_work_times;
         },
     },
 };


### PR DESCRIPTION

## 這個 PR 是？ <!-- 必填 -->

寫 `query { salary_work_times }` 的 resolver

## 若可以手動測試，要如何測試？ <!-- 選填 -->

- [ ] 測以下 query 
```graphql
{
  salary_work_times(start: 0, limit: 20) {
    id
    salary {
      type
      amount
    }
    created_at
  }
}
```

