### PR TITLE
insert view_logs when querying salaryWorkTimes and experiences

### DIFF
--- a/models/working_model.js
+++ b/models/working_model.js
@@ -17,7 +17,7 @@ class WorkingModel {
      */
     getWorkings(
         query,
-        sort = { create_id: -1 },
+        sort = { created_at: -1 },
         skip = 0,
         limit = 25,
         opt = {}

--- a/schema/experience.js
+++ b/schema/experience.js
@@ -1,5 +1,5 @@
 const { gql } = require("apollo-server-express");
-const ObjectId = require("mongodb").ObjectId;
+const { ObjectId } = require("mongodb");
 
 const WorkExperienceType = "work";
 const InterviewExperienceType = "interview";
@@ -142,6 +142,13 @@ const resolvers = {
                 _id: ObjectId(id),
                 status: "published",
                 "archive.is_archived": false,
+            });
+
+            ctx.db.collection("view_logs").insertOne({
+                user_id: ObjectId(ctx.user._id),
+                content_id: ObjectId(id),
+                content_type: "experience",
+                created_at: new Date(),
             });
 
             if (!result) {

--- a/schema/experience.js
+++ b/schema/experience.js
@@ -1,5 +1,6 @@
 const { gql } = require("apollo-server-express");
 const { ObjectId } = require("mongodb");
+const R = require("ramda");
 
 const WorkExperienceType = "work";
 const InterviewExperienceType = "interview";
@@ -144,8 +145,10 @@ const resolvers = {
                 "archive.is_archived": false,
             });
 
+            const userId = R.path(["user", "_id"], ctx);
+
             ctx.db.collection("view_logs").insertOne({
-                user_id: ObjectId(ctx.user._id),
+                user_id: userId ? ObjectId(userId) : undefined,
                 content_id: ObjectId(id),
                 content_type: "experience",
                 created_at: new Date(),

--- a/schema/salary_work_time.js
+++ b/schema/salary_work_time.js
@@ -222,9 +222,10 @@ const resolvers = {
             );
 
             if (salary_work_times.length > 0) {
+                const userId = R.path(["_id"], user);
                 const current = new Date();
                 const logs = salary_work_times.map(salaryWorkTime => ({
-                    user_id: ObjectId(user._id),
+                    user_id: userId ? ObjectId(userId) : undefined,
                     content_id: ObjectId(salaryWorkTime._id),
                     content_type: "salary_work_time",
                     created_at: current,


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

#530 
view_logs 的實做

<!-- 請說明這個 PR 做了什麼 -->

在每次 query salaryWorkTimes 或是 experiences 的時候，塞資料進 view_logs

## 若可以手動測試，要如何測試？ <!-- 選填 -->

打 salary_work_times 或 experience 的 query 都會觸發

## 補充

我這邊把 view_logs 的欄位從 user 改成 user_id 喔！
user 那欄位的意義應該是 user 的 _id 而不是 user 的其他資料