### PR TITLE
Feature: add about_this_job to SalaryWorkTime

### DIFF
--- a/src/schema/salary_work_time.js
+++ b/src/schema/salary_work_time.js
@@ -22,6 +22,7 @@ const Type = gql`
         created_at: Date!
         data_time: YearMonth!
         estimated_hourly_wage: Float
+        about_this_job: String
     }
 
     type SalaryWorkTimeStatistics {


### PR DESCRIPTION
Close https://github.com/goodjoblife/GoodJobShare/pull/675

## 這個 PR 是？ <!-- 必填 -->

SalaryWorkTime 加上 about_this_job 欄位

## 若可以手動測試，要如何測試？ <!-- 選填 -->

- [ ] 如果有 production dump ，找 "和碩聯合科技股份有限公司" ，會有至少一筆資料有 about_this_job 。如果沒有資料，那只能自己創了

Query:

```graphql
{
  company(name: "和碩聯合科技股份有限公司") {
    salary_work_times {
      about_this_job
    }
  }
}
```