### PR TITLE
Feature: add Query popular experiences

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - REDIS_URL=redis://redis
       - NODE_ENV=development
     # other variables, use .env
+      - JWT_SECRET=DontUseMe
+      - VERIFY_EMAIL_JWT_SECRET=DontUseMe
   mongo:
     image: mongo:3.6
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,6 @@ services:
       - REDIS_URL=redis://redis
       - NODE_ENV=development
     # other variables, use .env
-      - JWT_SECRET=DontUseMe
-      - VERIFY_EMAIL_JWT_SECRET=DontUseMe
   mongo:
     image: mongo:3.6
   redis:

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "chai-datetime": "^1.4.1",
+    "chai-subset": "^1.6.0",
     "eslint": "^5.14.1",
     "eslint-config-prettier": "^4.0.0",
     "eslint-plugin-prettier": "^3.0.1",

--- a/src/schema/experience.js
+++ b/src/schema/experience.js
@@ -115,7 +115,10 @@ const Query = gql`
     extend type Query {
         "取得單篇經驗分享"
         experience(id: ID!): Experience
-        popular_experiences: [Experience!]!
+        popular_experiences(
+            returnNumber: Int = 3
+            sampleNumber: Int = 20
+        ): [Experience!]!
     }
 `;
 
@@ -185,8 +188,9 @@ const resolvers = {
             }
         },
 
-        async popular_experiences(_, __, ctx) {
+        async popular_experiences(_, args, ctx) {
             const collection = ctx.db.collection("experiences");
+            const { returnNumber, sampleNumber } = args;
 
             const thirtyDays = 30 * 24 * 60 * 60 * 1000;
 
@@ -223,11 +227,11 @@ const resolvers = {
                         },
                     },
                     {
-                        $limit: 20,
+                        $limit: sampleNumber,
                     },
                     {
                         $sample: {
-                            size: 3,
+                            size: returnNumber,
                         },
                     },
                 ])

--- a/src/schema/experience.test.js
+++ b/src/schema/experience.test.js
@@ -1,7 +1,10 @@
-const { assert, expect } = require("chai");
+const chai = require("chai");
 const request = require("supertest");
 const { connectMongo } = require("../models/connect");
 
+chai.use(require("chai-subset"));
+
+const { assert, expect } = chai;
 const app = require("../app");
 
 describe("Query popular_experiences", () => {
@@ -56,10 +59,10 @@ describe("Query popular_experiences", () => {
         ])
     );
 
-    it("will return 3 sample experiences", async () => {
+    it("will return experiences in thirty days", async () => {
         const payload = {
             query: `{
-                    popular_experiences {
+                    popular_experiences(returnNumber: 4, sampleNumber: 4) {
                         id
                         title
                     }
@@ -75,10 +78,34 @@ describe("Query popular_experiences", () => {
 
         assert.isArray(popular_experiences);
         assert.lengthOf(popular_experiences, 3);
-        expect(popular_experiences).to.not.deep.include({ title: "hot" });
+        expect(popular_experiences).containSubset([{ title: "cold" }]);
+        expect(popular_experiences).to.not.containSubset([{ title: "hot" }]);
+    });
+
+    it("will experiences with most number of words", async () => {
+        const payload = {
+            query: `{
+                    popular_experiences(returnNumber: 2, sampleNumber: 2) {
+                        id
+                        title
+                    }
+                }`,
+            variables: null,
+        };
+        const res = await request(app)
+            .post("/graphql")
+            .send(payload)
+            .expect(200);
+
+        const { popular_experiences } = res.body.data;
+
+        assert.isArray(popular_experiences);
+        assert.lengthOf(popular_experiences, 2);
+        expect(popular_experiences).containSubset([{ title: "cold" }]);
+        expect(popular_experiences).containSubset([{ title: "gentle" }]);
     });
 
     after(async () => {
-        return db.collection("experiences").drop();
+        return db.collection("experiences").deleteMany({});
     });
 });

--- a/src/schema/experience.test.js
+++ b/src/schema/experience.test.js
@@ -1,0 +1,84 @@
+const { assert, expect } = require("chai");
+const request = require("supertest");
+const { connectMongo } = require("../models/connect");
+
+const app = require("../app");
+
+describe("Query popular_experiences", () => {
+    let db;
+
+    before(async () => {
+        ({ db } = await connectMongo());
+    });
+
+    before(() =>
+        db.collection("experiences").insertMany([
+            {
+                created_at: new Date(),
+                type: "work",
+                title: "ugly",
+                sections: [
+                    {
+                        content: "我很醜",
+                    },
+                ],
+            },
+            {
+                created_at: new Date(),
+                type: "work",
+                title: "gentle",
+                sections: [
+                    {
+                        content: "可是我很溫柔",
+                    },
+                ],
+            },
+            {
+                created_at: new Date(),
+                type: "work",
+                title: "cold",
+                sections: [
+                    {
+                        content: "外表冷漠",
+                    },
+                ],
+            },
+            {
+                created_at: new Date(new Date() - 100 * 24 * 60 * 60 * 1000),
+                type: "work",
+                title: "hot",
+                sections: [
+                    {
+                        content: "內心狂熱",
+                    },
+                ],
+            },
+        ])
+    );
+
+    it("will return 3 sample experiences", async () => {
+        const payload = {
+            query: `{
+                    popular_experiences {
+                        id
+                        title
+                    }
+                }`,
+            variables: null,
+        };
+        const res = await request(app)
+            .post("/graphql")
+            .send(payload)
+            .expect(200);
+
+        const { popular_experiences } = res.body.data;
+
+        assert.isArray(popular_experiences);
+        assert.lengthOf(popular_experiences, 3);
+        expect(popular_experiences).to.not.deep.include({ title: "hot" });
+    });
+
+    after(async () => {
+        return db.collection("experiences").drop();
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -842,6 +842,11 @@ chai-datetime@^1.4.1:
   dependencies:
     chai ">1.9.0"
 
+chai-subset@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/chai-subset/-/chai-subset-1.6.0.tgz#a5d0ca14e329a79596ed70058b6646bd6988cfe9"
+  integrity sha1-pdDKFOMpp5WW7XAFi2ZGvWmIz+k=
+
 chai@>1.9.0, "chai@>=1.9.2 <4.0.0", chai@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/chai/-/chai-3.5.0.tgz#4d02637b067fe958bdbfdd3a40ec56fef7373247"


### PR DESCRIPTION

## 這個 PR 是？ <!-- 必填 -->

#553 
`選出最近一個月字數總和最多的 20 篇文章，亂數取 3 篇放在首頁`
這個的 API

<!-- 請說明這個 PR 做了什麼 -->

## 我應該從何看起？  <!-- 選填，沒有就刪掉 -->

Query popular_experiences 重點在 mongodb aggregation
- 首先先找出近 30 天的資料
- 加上個欄位 contentsLength 計算出每篇文章中 `sections.content` 加總起來的字數
- 排序
- 抓出前 20 筆資料
- 隨機挑 3 筆

## 若可以手動測試，要如何測試？ <!-- 選填 -->

- 準備好資料後，打 /graphql