### PR TITLE
Feature: Logging graphql error

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -84,6 +84,13 @@ setupGraphql(app, {
         manager: req.manager,
         user: req.user,
     }),
+    formatError: err => {
+        winston.warn("", {
+            message: err.message,
+            error: err,
+        });
+        return err;
+    },
 });
 
 // catch 404 and forward to error handler


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

對於 apollo server 產出的 error，express 會視為正常 response，所以特別 logging
