### PR TITLE
refactor: increase experience.title length to 50 chars

### DIFF
--- a/src/routes/interview_experiences/index.js
+++ b/src/routes/interview_experiences/index.js
@@ -61,8 +61,8 @@ function validateCommonInputFields(data) {
     if (!requiredNonEmptyString(data.title)) {
         throw new HttpError("標題要寫喔！", 422);
     }
-    if (!stringRequireLength(data.title, 1, 25)) {
-        throw new HttpError("標題僅限 1~25 字！", 422);
+    if (!stringRequireLength(data.title, 1, 50)) {
+        throw new HttpError("標題僅限 1~50 字！", 422);
     }
 
     if (!data.sections || !(data.sections instanceof Array)) {
@@ -301,7 +301,7 @@ function validationInputFields(data) {
  * @apiParam {String="year","month","day","hour"} salary.type 面談薪資種類 (若有上傳面談薪資欄位，本欄必填)
  * @apiParam {Number="整數, >= 0"} salary.amount 面談薪資金額 (若有上傳面談薪資欄位，本欄必填)
  * @apiParam {Number="整數, 1~5"} overall_rating 整體面試滿意度
- * @apiParam {String="0 < length <= 25 "} title 整篇經驗分享的標題
+ * @apiParam {String="0 < length <= 50 "} title 整篇經驗分享的標題
  * @apiParam {Object[]} sections 整篇內容
  * @apiParam {String="0 < length <= 25" || NULL} sections.subtitle 段落標題
  * @apiParam {String="0 < length <= 5000"} sections.content 段落內容

--- a/src/routes/interview_experiences/index.test.js
+++ b/src/routes/interview_experiences/index.test.js
@@ -219,12 +219,12 @@ describe("experiences 面試和工作經驗資訊", () => {
                     .set("Authorization", `Bearer ${fake_user_token}`)
                     .expect(422));
 
-            it("title of word is more than 25 char , expected return 422", () =>
+            it("title of word is more than 50 char , expected return 422", () =>
                 request(app)
                     .post("/interview_experiences")
                     .send(
                         generateInterviewExperiencePayload({
-                            title: new Array(30).join("今"),
+                            title: new Array(60).join("今"),
                         })
                     )
                     .set("Authorization", `Bearer ${fake_user_token}`)
@@ -300,8 +300,8 @@ describe("experiences 面試和工作經驗資訊", () => {
                     .set("Authorization", `Bearer ${fake_user_token}`)
                     .expect(200));
 
-            it("subtitle of word is more than 25 char, expected return 422", () => {
-                const words = new Array(40).join("慘");
+            it("subtitle of word is more than 50 char, expected return 422", () => {
+                const words = new Array(60).join("慘");
                 return request(app)
                     .post("/interview_experiences")
                     .send(

--- a/src/routes/work_experiences/index.js
+++ b/src/routes/work_experiences/index.js
@@ -61,8 +61,8 @@ function validateCommonInputFields(data) {
     if (!requiredNonEmptyString(data.title)) {
         throw new HttpError("標題要寫喔！", 422);
     }
-    if (!stringRequireLength(data.title, 1, 25)) {
-        throw new HttpError("標題僅限 1~25 字！", 422);
+    if (!stringRequireLength(data.title, 1, 50)) {
+        throw new HttpError("標題僅限 1~50 字！", 422);
     }
 
     if (!data.sections || !(data.sections instanceof Array)) {
@@ -272,7 +272,7 @@ function pickupWorkExperience(input) {
  * @apiParam {Number="整數, >= 0"} salary.amount 薪資金額 (若有上傳薪資欄位，本欄必填)
  * @apiParam {Number="整數或浮點數。 168>=N>=0。"} [week_work_time] 一週工時
  * @apiParam {String="yes","no"} [recommend_to_others] 是否推薦此工作
- * @apiParam {String="0 < length <= 25 "} title 整篇經驗分享的標題
+ * @apiParam {String="0 < length <= 50 "} title 整篇經驗分享的標題
  * @apiParam {Object[]} sections 整篇內容
  * @apiParam {String="0 < length <= 25" || NULL} sections.subtitle 段落標題
  * @apiParam {String="0 < length <= 5000"} sections.content 段落內容

--- a/src/routes/work_experiences/index.test.js
+++ b/src/routes/work_experiences/index.test.js
@@ -239,12 +239,12 @@ describe("experiences 面試和工作經驗資訊", () => {
                     .set("Authorization", `Bearer ${fake_user_token}`)
                     .expect(422));
 
-            it("title of word is more than 25 char , expected return 422", () =>
+            it("title of word is more than 50 char , expected return 422", () =>
                 request(app)
                     .post("/work_experiences")
                     .send(
                         generateWorkExperiencePayload({
-                            title: new Array(30).join("今"),
+                            title: new Array(60).join("今"),
                         })
                     )
                     .set("Authorization", `Bearer ${fake_user_token}`)


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

有使用者反映標題長度太短，公司名稱太長時，就會導致錯誤訊息
因此把經驗分享標題的字數拉到 50 個字

## 若可以手動測試，要如何測試？ <!-- 選填 -->

- [ ] 拉前端 https://github.com/goodjoblife/GoodJobShare/pull/699 ，進行測試
