### PR TITLE
hotfix: add upper limit of salary amount to prevent graphql error

### DIFF
--- a/src/routes/workings/workings_post.js
+++ b/src/routes/workings/workings_post.js
@@ -334,6 +334,9 @@ function validateSalaryData(req) {
     if (custom.salary_amount < 0) {
         throw new HttpError("薪資不小於0", 422);
     }
+    if (custom.salary_amount > 100000000) {
+        throw new HttpError("薪資不大於一億", 422);
+    }
 
     if (!data.experience_in_year) {
         throw new HttpError("相關職務工作經驗必填", 422);


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

今晚真的是 bug 之夜 orz。
意外發現 graphql 的 int type 的數字範圍是 32-bit sign int ，所以大於 2147483647 的數字都會噴錯。
我們確實有兩筆資料有這樣的狀況，會造成 graphql 出錯，間接造成無法 render。
目前已經把那兩筆都鎖起來了

這個 PR 則是限制薪資的最上限，避免超過整數上限。

## 若可以手動測試，要如何測試？ <!-- 選填 -->

- [ ] 故意輸入大於一億的薪資，應該要出錯
