### PR TITLE
Feature: 實作 company/job_title > work_experience/interview_experience

### DIFF
--- a/src/models/experience_model_v2.js
+++ b/src/models/experience_model_v2.js
@@ -1,0 +1,69 @@
+const R = require("ramda");
+const DataLoader = require("dataloader");
+
+class ExperienceModel {
+    constructor(manager, type) {
+        this.manager = manager;
+        this.type = type;
+        this.collection = manager.db.collection("experiences");
+
+        this.byCompanyLoader = new DataLoader(async names => {
+            const experiences = await this.findByCompanyNames(names, type);
+            const toGroup = R.groupBy(x => x.company.name);
+            const group = toGroup(experiences);
+            const results = R.pipe(
+                R.flip(R.props)(group),
+                R.map(R.defaultTo([]))
+            )(names);
+
+            return results;
+        });
+
+        this.byJobTitleLoader = new DataLoader(async job_titles => {
+            const experiences = await this.findByJobTitles(job_titles, type);
+
+            const toGroup = R.groupBy(x => x.job_title);
+            const group = toGroup(experiences);
+            const results = R.pipe(
+                R.flip(R.props)(group),
+                R.map(R.defaultTo([]))
+            )(job_titles);
+
+            return results;
+        });
+    }
+
+    async findByCompanyNames(names, type) {
+        // 特殊 find，為了給 dataloader 用
+        return await this.collection
+            .find({
+                status: "published",
+                "archive.is_archived": false,
+                "company.name": { $in: names },
+                type,
+            })
+            .sort({ created_at: -1 })
+            .toArray();
+    }
+
+    async findByJobTitles(job_titles, type) {
+        // 特殊 find，為了給 dataloader 用
+        return await this.collection
+            .find({
+                status: "published",
+                "archive.is_archived": false,
+                job_title: { $in: job_titles },
+                type,
+            })
+            .sort({ created_at: -1 })
+            .toArray();
+    }
+}
+
+ExperienceModel.TYPE = {
+    WORK: "work",
+    INTERN: "intern",
+    INTERVIEW: "interview",
+};
+
+module.exports = ExperienceModel;

--- a/src/models/manager.js
+++ b/src/models/manager.js
@@ -44,11 +44,27 @@ class ModelManager {
     }
 
     get WorkExperienceModel() {
-        return new ExperienceModel(this, ExperienceModel.TYPE.WORK);
+        // Note: if you use dataLoader in Model, you can only create
+        // one instance of model.
+        if (!this._work_experience_model) {
+            this._work_experience_model = new ExperienceModel(
+                this,
+                ExperienceModel.TYPE.WORK
+            );
+        }
+        return this._work_experience_model;
     }
 
     get InterviewExperienceModel() {
-        return new ExperienceModel(this, ExperienceModel.TYPE.INTERVIEW);
+        // Note: if you use dataLoader in Model, you can only create
+        // one instance of model.
+        if (!this._interview_experience_model) {
+            this._interview_experience_model = new ExperienceModel(
+                this,
+                ExperienceModel.TYPE.INTERVIEW
+            );
+        }
+        return this._interview_experience_model;
     }
 }
 

--- a/src/models/manager.js
+++ b/src/models/manager.js
@@ -5,6 +5,7 @@ const JobTitleKeywordModel = require("./job_title_keyword_model");
 const SalaryWorkTimeModel = require("./salary_work_time_model");
 const UserModel = require("./user_model");
 const ViewLogModel = require("./view_log_model");
+const ExperienceModel = require("./experience_model_v2");
 
 class ModelManager {
     constructor(db) {
@@ -40,6 +41,14 @@ class ModelManager {
 
     get ViewLogModel() {
         return new ViewLogModel(this);
+    }
+
+    get WorkExperienceModel() {
+        return new ExperienceModel(this, ExperienceModel.TYPE.WORK);
+    }
+
+    get InterviewExperienceModel() {
+        return new ExperienceModel(this, ExperienceModel.TYPE.INTERVIEW);
     }
 }
 

--- a/src/schema/company.js
+++ b/src/schema/company.js
@@ -81,14 +81,8 @@ const resolvers = {
                 "company.name": name,
             });
 
-            if (companyFromSalaryWorkTime) {
-                return {
-                    name: companyFromSalaryWorkTime.company.name,
-                };
-            } else if (companyFromExperience) {
-                return {
-                    name: companyFromExperience.company.name,
-                };
+            if (companyFromSalaryWorkTime || companyFromExperience) {
+                return { name };
             } else {
                 return null;
             }

--- a/src/schema/company.js
+++ b/src/schema/company.js
@@ -63,22 +63,35 @@ const resolvers = {
         },
 
         company: async (_, { name }, ctx) => {
-            const collection = ctx.db.collection("workings");
+            const salaryWorkTimeCollection = ctx.db.collection("workings");
+            const experienceCollection = ctx.db.collection("experiences");
 
-            // FIXME: should query from collection `companies`
-            const result = await collection.findOne({
+            // 只要 salaryWorkTime / experiences 任一邊有出現，就不會回傳 null
+            const companyFromSalaryWorkTime = await salaryWorkTimeCollection.findOne(
+                {
+                    status: "published",
+                    "archive.is_archived": false,
+                    "company.name": name,
+                }
+            );
+
+            const companyFromExperience = await experienceCollection.findOne({
                 status: "published",
                 "archive.is_archived": false,
                 "company.name": name,
             });
 
-            if (!result) {
+            if (companyFromSalaryWorkTime) {
+                return {
+                    name: companyFromSalaryWorkTime.company.name,
+                };
+            } else if (companyFromExperience) {
+                return {
+                    name: companyFromExperience.company.name,
+                };
+            } else {
                 return null;
             }
-
-            return {
-                name: result.company.name,
-            };
         },
     },
     Company: {
@@ -92,9 +105,16 @@ const resolvers = {
                 company.name
             );
         },
-        // TODO
-        work_experiences: () => {},
-        interview_experiences: () => {},
+        work_experiences: async (company, _, { manager }) => {
+            return await manager.WorkExperienceModel.byCompanyLoader.load(
+                company.name
+            );
+        },
+        interview_experiences: async (company, _, { manager }) => {
+            return await manager.InterviewExperienceModel.byCompanyLoader.load(
+                company.name
+            );
+        },
         work_experience_statistics: () => {},
         interview_experience_statistics: () => {},
     },

--- a/src/schema/job_title.js
+++ b/src/schema/job_title.js
@@ -74,9 +74,17 @@ const resolvers = {
                 jobTitle.name
             );
         },
+        work_experiences: async (jobTitle, _, { manager }) => {
+            return await manager.WorkExperienceModel.byJobTitleLoader.load(
+                jobTitle.name
+            );
+        },
+        interview_experiences: async (jobTitle, _, { manager }) => {
+            return await manager.InterviewExperienceModel.byJobTitleLoader.load(
+                jobTitle.name
+            );
+        },
         // TODO
-        work_experiences: () => {},
-        interview_experiences: () => {},
         work_experience_statistics: () => {},
         interview_experience_statistics: () => {},
     },


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

實作 
```
company(name:"xxx") {
  work_experiences
  interview_experiences
}
```
和

```
job_title(name:"xxx") {
  work_experiences
  interview_experiences
}
```

這個希望盡快 review & merge，因為前端 @WendellLiu  @peteranny  在做公司/職業頁面要用到，他們被這些 API 卡住

## 若可以手動測試，要如何測試？ <!-- 選填 -->

- [ ] load production dump
- [ ] graphql 測試範例 query

```graphql
query {
  company(name: "聯發科") {
    name
    salary_work_times {
      id
    }
    work_experiences {
      id
      type
    	region
      experience_in_year
      education
      salary {
        amount
        type
      }
      title
      sections {
        subtitle
        content
      }
      created_at
      reply_count
      like_count
    }
 interview_experiences {
      id
      type
    	region
      experience_in_year
      education
      salary {
        amount
        type
      }
      title
      sections {
        subtitle
        content
      }
      created_at
      reply_count
      like_count
    }
  }
}
```
- [ ] 換幾間公司看看（可以找只有單一種資料的公司測試看看）
- [ ] 換測 job-title