### PR TITLE
Feature: calculate view_count from view_logs by script

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "lru-cache": "^5.1.1",
     "mongodb": "^3.1.1",
     "morgan": "^1.9.1",
+    "p-map": "^3.0.0",
     "passport": "^0.4.0",
     "passport-http-bearer": "^1.0.1",
     "passport-jwt": "^4.0.0",

--- a/scripts/updateViewCount.js
+++ b/scripts/updateViewCount.js
@@ -1,0 +1,87 @@
+require("dotenv").config();
+
+const pMap = require("p-map");
+const { ObjectId } = require("mongodb");
+
+const { connectMongo } = require("../src/models/connect");
+const ModelManager = require("../src/models/manager");
+
+(async () => {
+    const { db, client } = await connectMongo();
+    const { ViewLogModel, SalaryWorkTimeModel } = new ModelManager(db);
+
+    try {
+        const salaryWorkTimeViewLogs = await ViewLogModel.collection
+            .aggregate([
+                {
+                    $match: {
+                        content_type: "SALARY_WORK_TIME",
+                        has_calculated_view_count: { $ne: true },
+                    },
+                },
+                {
+                    $group: {
+                        _id: "$content_id",
+                        content_id: { $first: "$content_id" },
+                        view_count: { $sum: 1 },
+                    },
+                },
+            ])
+            .toArray();
+
+        await pMap(
+            salaryWorkTimeViewLogs,
+            viewLog => {
+                return SalaryWorkTimeModel.collection.updateOne(
+                    { _id: ObjectId(viewLog.content_id) },
+                    { $inc: { view_count: viewLog.view_count } }
+                );
+            },
+            { concurrency: 10 }
+        );
+
+        const experienceViewLogs = await ViewLogModel.collection
+            .aggregate([
+                {
+                    $match: {
+                        content_type: "EXPERIENCE",
+                        has_calculated_view_count: { $ne: true },
+                    },
+                },
+                {
+                    $group: {
+                        _id: "$content_id",
+                        content_id: { $first: "$content_id" },
+                        view_count: { $sum: 1 },
+                    },
+                },
+            ])
+            .toArray();
+
+        await pMap(
+            experienceViewLogs,
+            viewLog => {
+                return db
+                    .collection("experiences")
+                    .updateOne(
+                        { _id: ObjectId(viewLog.content_id) },
+                        { $inc: { view_count: viewLog.view_count } }
+                    );
+            },
+            { concurrency: 10 }
+        );
+
+        await ViewLogModel.collection.updateMany(
+            { content_type: { $in: ["SALARY_WORK_TIME", "EXPERIENCE"] } },
+            {
+                $set: {
+                    has_calculated_view_count: true,
+                },
+            }
+        );
+    } catch (err) {
+        console.error(err);
+    } finally {
+        await client.close();
+    }
+})();

--- a/src/models/view_log_model.js
+++ b/src/models/view_log_model.js
@@ -1,6 +1,6 @@
 /*
  * ViewLog {
- *   _id            : ObjectId!
+ *   _id         : ObjectId!
  *   user_id     : ObjectId
  *   action      : String!
  *   content_id  : ObjectId!

--- a/src/schema/view_log.js
+++ b/src/schema/view_log.js
@@ -54,6 +54,7 @@ const resolvers = {
             const content_ids = content_ids_raw.map(x => ObjectId(x));
             const referrer = referrer_raw ? referrer_raw : null;
 
+            // TODO: should insert log by empty user?
             const user_id = user ? user._id : null;
             const current = new Date();
             const logs = content_ids.map(content_id => ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -229,6 +229,14 @@ acorn@^6.0.7:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.0.tgz#b0a3be31752c97a0f7013c5f4903b71a05db6818"
   integrity sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==
 
+aggregate-error@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.0.0.tgz#5b5a3c95e9095f311c9ab16c19fb4f3527cd3f79"
+  integrity sha512-yKD9kEoJIR+2IFqhMwayIBgheLYbB3PS2OBhWae1L/ODTd/JF/30cW0bc9TqzRL3k4U41Dieu3BF4I29p8xesA==
+  dependencies:
+    clean-stack "^2.0.0"
+    indent-string "^3.2.0"
+
 ajv@^4.9.1:
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.6.tgz#947e93049790942b2a2d60a8289b28924d39f987"
@@ -947,6 +955,11 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+clean-stack@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
+  integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
 cli-boxes@^1.0.0:
   version "1.0.0"
@@ -2460,7 +2473,7 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
-indent-string@^3.0.0:
+indent-string@^3.0.0, indent-string@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
   integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
@@ -3814,6 +3827,13 @@ p-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.0.0.tgz#be18c5a5adeb8e156460651421aceca56c213a50"
   integrity sha512-GO107XdrSUmtHxVoi60qc9tUl/KkNKm+X2CF4P9amalpGxv5YqVPJNfSb0wcA+syCopkZvYYIzW8OVTQW59x/w==
+
+p-map@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-3.0.0.tgz#d704d9af8a2ba684e2600d9a215983d4141a979d"
+  integrity sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==
+  dependencies:
+    aggregate-error "^3.0.0"
 
 p-try@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
#530 

## 這個 PR 是？ <!-- 必填 -->

現在 view_logs 有資料了，還差把資料整理算成 view_count，並把值加進職場或薪資工時的 collection

## 我應該從何看起？  <!-- 選填，沒有就刪掉 -->

把 logs 從 view_logs 裡面拉出來
-> 把相同 id 的職場或薪資經驗做 group 
-> 計算數量
-> 更新對應的 experiences / workings 的 view_count 欄位

這個 script 會有點稍稍污染到 view_logs 的 document
會塞個 `has_calculated_view_count` 來紀錄這個 document 有沒有在跑這次 script 之前就被算過

這邊有使用個套件 `p-map`，防止一次更新太多資料會對 mongodb 造成太大負擔

## 若可以手動測試，要如何測試？ <!-- 選填 -->

- 要先塞假資料進 view_logs 裡面，可以透過 mutation viewExperiences or viewSalaryWorkTimes
- 之後執行 `node scripts/updateViewCount.js` 就好了
- 執行完，在對應的 experiences / workings collection 的 document 應該會有計算完的 view_count 欄位

