### PR TITLE
Feature: send performance email when experiences reach the threshold

### DIFF
--- a/bin/sendPerformanceEmail
+++ b/bin/sendPerformanceEmail
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+const sendPerformanceEmail = require("../scripts/sendPerformanceEmail");
+
+sendPerformanceEmail().catch(console.error);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node ./bin/www",
     "dev": "nodemon ./bin/www",
-    "test": "mocha --recursive src --require ./test/config-env.js --exit",
+    "test": "mocha --recursive scripts/*.test.js src/**/*.test.js --require ./test/config-env.js --exit",
     "test:one": "mocha --require ./test/config-env.js --exit --file",
     "lint": "eslint \"./**/*.js\"",
     "lint:fix": "npm run lint -- --fix",

--- a/scripts/sendPerformanceEmail.js
+++ b/scripts/sendPerformanceEmail.js
@@ -5,7 +5,6 @@ const { ObjectId } = require("mongodb");
 
 const { connectMongo } = require("../src/models/connect");
 const ExperienceModel = require("../src/models/experience_model");
-const ModelManager = require("../src/models/manager");
 
 const {
     ExperienceViewLogNotificationTemplate,
@@ -17,8 +16,6 @@ const GOODJOB_DOMAIN = "https://www.goodjob.life";
 (async () => {
     const { db, client } = await connectMongo();
     const experienceModel = new ExperienceModel(db);
-    const manager = new ModelManager(db);
-    const { UserModel } = manager;
 
     // order is important
     const viewCountThreshold = [1000, 500, 100];
@@ -35,104 +32,161 @@ const GOODJOB_DOMAIN = "https://www.goodjob.life";
                         },
                     },
                     {
-                        $group: {
-                            _id: "$author_id",
-                            workings: {
-                                $push: {
-                                    _id: "$_id",
-                                    title: "$title",
-                                    content: "$content",
-                                    url: {
-                                        $concat: [
-                                            `${GOODJOB_DOMAIN}/experiences/`,
-                                            { $toString: "$_id" },
-                                        ],
-                                    },
-                                    viewCount: "$view_count",
-                                    type: "$type",
-                                    sections: "$sections",
-                                },
-                            },
+                        $lookup: {
+                            from: "users",
+                            localField: "author_id",
+                            foreignField: "_id",
+                            as: "user",
                         },
                     },
                     {
-                        $lookup: {
-                            from: "users",
-                            localField: "_id",
-                            foreignField: "_id",
-                            as: "user",
+                        $match: {
+                            "user.subscribeEmail": true,
+                            "user.email": { $exists: true },
                         },
                     },
                     {
                         $unwind: "$user",
                     },
                     {
-                        $match: {
-                            "user.subscribeEmail": true,
-                            "user.email": { $exists: true },
-                            $or: [
-                                {
-                                    // before 14 days
-                                    "user.last_email_time": {
-                                        $lt: new Date(
-                                            new Date() -
-                                                1000 * 60 * 60 * 24 * 14
-                                        ),
-                                    },
+                        $lookup: {
+                            from: "email_logs",
+                            localField: "user._id",
+                            foreignField: "user_id",
+                            as: "user.email_logs",
+                        },
+                    },
+                    {
+                        $group: {
+                            _id: "$author_id",
+                            experiences: {
+                                $push: {
+                                    _id: "$_id",
+                                    title: "$title",
+                                    viewCount: "$view_count",
+                                    type: "$type",
+                                    sections: "$sections",
                                 },
-                                { "user.last_email_time": { $exists: false } },
-                            ],
+                            },
+                            user: {
+                                $first: "$user",
+                            },
                         },
                     },
                 ])
                 .toArray();
 
-            const template = new ExperienceViewLogNotificationTemplate();
+            const userWithNewExperiences = userWithExperiences
+                .filter(userWithExperience => {
+                    const {
+                        user: { email_logs: emailLogs },
+                    } = userWithExperience;
 
-            const emailInfos = userWithExperiences.map(userWithExperience => {
-                // TODO: maybe send multiple experiences in one email
-                const experience = userWithExperience.workings[0];
-                const content = experience.sections
-                    .map(section => section.content)
-                    .join("\n");
+                    return (
+                        emailLogs.length === 0 ||
+                        // 全部的 email logs 都是兩週前的
+                        emailLogs.every(
+                            log =>
+                                new Date(log.created_at) <
+                                new Date(new Date() - 1000 * 60 * 60 * 24 * 14)
+                        )
+                    );
+                })
+                .map(userWithExperience => {
+                    const {
+                        experiences,
+                        user: { email_logs: emailLogs },
+                    } = userWithExperience;
 
-                let typeName;
-                if (experience.type === "intern") {
-                    typeName = "實習心得";
-                } else if (experience.type === "interview") {
-                    typeName = "面試經驗";
-                } else {
-                    typeName = "工作心得";
-                }
+                    // all experiences sent before
+                    const oldExperiences = emailLogs.map(
+                        emailLog => emailLog.reason
+                    );
 
-                return {
-                    email: userWithExperience.user.email,
-                    userId: userWithExperience.user._id,
-                    subject: {
-                        username: userWithExperience.user.name,
-                        experience: {
-                            title: experience.title,
-                            viewCount: experience.viewCount,
-                            url: experience.url,
-                            typeName,
-                            content,
+                    const newExperiences = experiences
+                        .filter(experience =>
+                            oldExperiences.every(
+                                old =>
+                                    // experience 以前從沒寄過信
+                                    old.experience_id.toString() !==
+                                        experience._id.toString() ||
+                                    // experience 有被寄過信，但是之前的 threshold 都比較小
+                                    (old.experience_id.toString() ===
+                                        experience._id.toString() &&
+                                        old.threshold < experience.viewCount &&
+                                        old.threshold !== threshold)
+                            )
+                        )
+                        .map(experience => ({
+                            ...experience,
+                            url: `${GOODJOB_DOMAIN}/experiences/${experience._id.toString()}`,
+                        }));
+
+                    return {
+                        ...userWithExperience,
+                        experiences: newExperiences,
+                    };
+                })
+                .filter(
+                    userWithExperience =>
+                        userWithExperience.experiences.length > 0
+                );
+
+            const emailInfos = userWithNewExperiences.map(
+                userWithExperience => {
+                    // TODO: maybe send multiple experiences in one email
+                    const experience = userWithExperience.experiences[0];
+                    const content = experience.sections
+                        .map(section => section.content)
+                        .join("\n");
+
+                    let typeName;
+                    if (experience.type === "intern") {
+                        typeName = "實習心得";
+                    } else if (experience.type === "interview") {
+                        typeName = "面試經驗";
+                    } else {
+                        typeName = "工作心得";
+                    }
+
+                    return {
+                        email: userWithExperience.user.email,
+                        emailLogs: {
+                            userId: userWithExperience.user._id,
+                            experienceId: experience._id,
                         },
-                    },
-                };
-            });
+                        subject: {
+                            username: userWithExperience.user.name,
+                            experience: {
+                                title: experience.title,
+                                viewCount: experience.viewCount,
+                                url: experience.url,
+                                typeName,
+                                content,
+                            },
+                        },
+                    };
+                }
+            );
+
+            const template = new ExperienceViewLogNotificationTemplate();
 
             await pMap(
                 emailInfos,
                 async emailInfo => {
-                    const { userId, email, subject } = emailInfo;
+                    const { emailLogs, email, subject } = emailInfo;
                     const current = new Date();
 
                     await sendEmailsFromTemplate([email], template, subject);
 
-                    await UserModel.collection.updateOne(
-                        { _id: ObjectId(userId) },
-                        { $set: { last_email_time: current } }
-                    );
+                    await db.collection("email_logs").insertOne({
+                        user_id: ObjectId(emailLogs.userId),
+                        created_at: current,
+                        reason: {
+                            experience_id: ObjectId(emailLogs.experienceId),
+                            threshold,
+                        },
+                    });
                 },
                 { concurrency: 10 }
             );

--- a/scripts/sendPerformanceEmail.js
+++ b/scripts/sendPerformanceEmail.js
@@ -9,11 +9,11 @@ const ExperienceModel = require("../src/models/experience_model");
 const {
     ExperienceViewLogNotificationTemplate,
 } = require("../src/libs/email_templates");
-const { sendEmailsFromTemplate } = require("../src/libs/email");
+const emailLib = require("../src/libs/email");
 
 const GOODJOB_DOMAIN = "https://www.goodjob.life";
 
-(async () => {
+const sendPerformanceEmail = async () => {
     const { db, client } = await connectMongo();
     const experienceModel = new ExperienceModel(db);
 
@@ -114,7 +114,7 @@ const GOODJOB_DOMAIN = "https://www.goodjob.life";
                                     (old.experience_id.toString() ===
                                         experience._id.toString() &&
                                         old.threshold < experience.viewCount &&
-                                        old.threshold !== threshold)
+                                        old.threshold < threshold)
                             )
                         )
                         .map(experience => ({
@@ -177,7 +177,11 @@ const GOODJOB_DOMAIN = "https://www.goodjob.life";
                     const { emailLogs, email, subject } = emailInfo;
                     const current = new Date();
 
-                    await sendEmailsFromTemplate([email], template, subject);
+                    await emailLib.sendEmailsFromTemplate(
+                        [email],
+                        template,
+                        subject
+                    );
 
                     await db.collection("email_logs").insertOne({
                         user_id: ObjectId(emailLogs.userId),
@@ -196,4 +200,6 @@ const GOODJOB_DOMAIN = "https://www.goodjob.life";
     } finally {
         await client.close();
     }
-})();
+};
+
+module.exports = sendPerformanceEmail;

--- a/scripts/sendPerformanceEmail.js
+++ b/scripts/sendPerformanceEmail.js
@@ -1,0 +1,145 @@
+require("dotenv").config();
+
+const pMap = require("p-map");
+const { ObjectId } = require("mongodb");
+
+const { connectMongo } = require("../src/models/connect");
+const ExperienceModel = require("../src/models/experience_model");
+const ModelManager = require("../src/models/manager");
+
+const {
+    ExperienceViewLogNotificationTemplate,
+} = require("../src/libs/email_templates");
+const { sendEmailsFromTemplate } = require("../src/libs/email");
+
+const GOODJOB_DOMAIN = "https://www.goodjob.life";
+
+(async () => {
+    const { db, client } = await connectMongo();
+    const experienceModel = new ExperienceModel(db);
+    const manager = new ModelManager(db);
+    const { UserModel } = manager;
+
+    // order is important
+    const viewCountThreshold = [1000, 500, 100];
+
+    try {
+        for (let threshold of viewCountThreshold) {
+            const userWithExperiences = await experienceModel.collection
+                .aggregate([
+                    {
+                        $match: {
+                            status: "published",
+                            "archive.is_archived": false,
+                            view_count: { $gte: threshold },
+                        },
+                    },
+                    {
+                        $group: {
+                            _id: "$author_id",
+                            workings: {
+                                $push: {
+                                    _id: "$_id",
+                                    title: "$title",
+                                    content: "$content",
+                                    url: {
+                                        $concat: [
+                                            `${GOODJOB_DOMAIN}/experiences/`,
+                                            { $toString: "$_id" },
+                                        ],
+                                    },
+                                    viewCount: "$view_count",
+                                    type: "$type",
+                                    sections: "$sections",
+                                },
+                            },
+                        },
+                    },
+                    {
+                        $lookup: {
+                            from: "users",
+                            localField: "_id",
+                            foreignField: "_id",
+                            as: "user",
+                        },
+                    },
+                    {
+                        $unwind: "$user",
+                    },
+                    {
+                        $match: {
+                            "user.subscribeEmail": true,
+                            "user.email": { $exists: true },
+                            $or: [
+                                {
+                                    // before 14 days
+                                    "user.last_email_time": {
+                                        $lt: new Date(
+                                            new Date() -
+                                                1000 * 60 * 60 * 24 * 14
+                                        ),
+                                    },
+                                },
+                                { "user.last_email_time": { $exists: false } },
+                            ],
+                        },
+                    },
+                ])
+                .toArray();
+
+            const template = new ExperienceViewLogNotificationTemplate();
+
+            const emailInfos = userWithExperiences.map(userWithExperience => {
+                // TODO: maybe send multiple experiences in one email
+                const experience = userWithExperience.workings[0];
+                const content = experience.sections
+                    .map(section => section.content)
+                    .join("\n");
+
+                let typeName;
+                if (experience.type === "intern") {
+                    typeName = "實習心得";
+                } else if (experience.type === "interview") {
+                    typeName = "面試經驗";
+                } else {
+                    typeName = "工作心得";
+                }
+
+                return {
+                    email: userWithExperience.user.email,
+                    userId: userWithExperience.user._id,
+                    subject: {
+                        username: userWithExperience.user.name,
+                        experience: {
+                            title: experience.title,
+                            viewCount: experience.viewCount,
+                            url: experience.url,
+                            typeName,
+                            content,
+                        },
+                    },
+                };
+            });
+
+            await pMap(
+                emailInfos,
+                async emailInfo => {
+                    const { userId, email, subject } = emailInfo;
+                    const current = new Date();
+
+                    await sendEmailsFromTemplate([email], template, subject);
+
+                    await UserModel.collection.updateOne(
+                        { _id: ObjectId(userId) },
+                        { $set: { last_email_time: current } }
+                    );
+                },
+                { concurrency: 10 }
+            );
+        }
+    } catch (err) {
+        console.error(err);
+    } finally {
+        await client.close();
+    }
+})();

--- a/scripts/sendPerformanceEmail.test.js
+++ b/scripts/sendPerformanceEmail.test.js
@@ -1,0 +1,168 @@
+const sinon = require("sinon");
+const { assert } = require("chai");
+const { ObjectId } = require("mongodb");
+
+const { connectMongo } = require("../src/models/connect");
+const sendPerformanceEmail = require("./sendPerformanceEmail");
+const emailLib = require("../src/libs/email");
+
+describe("sendPerformanceEmail", () => {
+    let db;
+    let sandbox;
+    const experienceId = "59074fbed17b7412779d1eed";
+    const userId = "59074fbed17b7412779d1eee";
+    let sendEmailsFromTemplate;
+
+    before(async () => {
+        ({ db } = await connectMongo());
+    });
+
+    beforeEach(async () => {
+        sandbox = sinon.sandbox.create();
+
+        await db.collection("experiences").insertMany([
+            {
+                _id: ObjectId(experienceId),
+                type: "interview",
+                author_id: ObjectId(userId),
+                company: {
+                    name: "goodjob company",
+                },
+                archive: {
+                    is_archived: false,
+                    reason: "",
+                },
+                status: "published",
+                title: "interview share",
+                sections: [
+                    {
+                        id: 0,
+                        subtitle: "面試過程",
+                        placeholder: "",
+                        titlePlaceholder: "段落標題，例：面試方式",
+                        content: "something just happens",
+                        isSubtitleEditable: false,
+                    },
+                ],
+                view_count: 555,
+            },
+        ]);
+
+        await db.collection("users").insertOne({
+            _id: ObjectId(userId),
+            name: "little people",
+            email: "test@goodjob.com",
+            subscribeEmail: true,
+        });
+
+        sendEmailsFromTemplate = sandbox.stub(
+            emailLib,
+            "sendEmailsFromTemplate"
+        );
+    });
+
+    it("sendEmailsFromTemplate should be called and only called once", async () => {
+        const subject = {
+            username: "little people",
+            experience: {
+                title: "interview share",
+                viewCount: 555,
+                url: `https://www.goodjob.life/experiences/${experienceId}`,
+                typeName: "面試經驗",
+                content: "something just happens",
+            },
+        };
+
+        await sendPerformanceEmail();
+
+        const logs = await db
+            .collection("email_logs")
+            .find()
+            .toArray();
+
+        assert.equal(logs.length, 1);
+        assert.isTrue(logs[0].user_id.equals(userId));
+        assert.isTrue(logs[0].reason.experience_id.equals(experienceId));
+        assert.propertyVal(logs[0].reason, "threshold", 500);
+
+        sinon.assert.calledOnce(sendEmailsFromTemplate);
+        sinon.assert.calledWithExactly(
+            sendEmailsFromTemplate,
+            ["test@goodjob.com"],
+            sinon.match.object,
+            subject
+        );
+    });
+
+    it("sendEmailsFromTemplate should not be called if last email is within two weeks", async () => {
+        await db.collection("email_logs").insertOne({
+            user_id: ObjectId(userId),
+            created_at: new Date(),
+            reason: {
+                experience_id: ObjectId(experienceId),
+                threshold: 77,
+            },
+        });
+
+        await sendPerformanceEmail();
+
+        sinon.assert.notCalled(sendEmailsFromTemplate);
+    });
+
+    it("sendEmailsFromTemplate should be called if last email is two weeks ago and exceed new threshold", async () => {
+        const threeWeeks = 1000 * 60 * 60 * 24 * 25;
+        await db.collection("email_logs").insertOne({
+            user_id: ObjectId(userId),
+            created_at: new Date(new Date() - threeWeeks),
+            reason: {
+                experience_id: ObjectId(experienceId),
+                threshold: 100,
+            },
+        });
+
+        const subject = {
+            username: "little people",
+            experience: {
+                title: "interview share",
+                viewCount: 555,
+                url: `https://www.goodjob.life/experiences/${experienceId}`,
+                typeName: "面試經驗",
+                content: "something just happens",
+            },
+        };
+
+        await sendPerformanceEmail();
+
+        sinon.assert.calledOnce(sendEmailsFromTemplate);
+        sinon.assert.calledWithExactly(
+            sendEmailsFromTemplate,
+            ["test@goodjob.com"],
+            sinon.match.object,
+            subject
+        );
+    });
+
+    it("sendEmailsFromTemplate should not be called if last email is two weeks ago but does not exceed new threshold", async () => {
+        const threeWeeks = 1000 * 60 * 60 * 24 * 25;
+        await db.collection("email_logs").insertOne({
+            user_id: ObjectId(userId),
+            created_at: new Date(new Date() - threeWeeks),
+            reason: {
+                experience_id: ObjectId(experienceId),
+                threshold: 1000,
+            },
+        });
+
+        await sendPerformanceEmail();
+
+        sinon.assert.notCalled(sendEmailsFromTemplate);
+    });
+
+    afterEach(async () => {
+        sandbox.restore();
+
+        await db.collection("experiences").deleteMany({});
+        await db.collection("users").deleteMany({});
+        await db.collection("email_logs").deleteMany({});
+    });
+});

--- a/test/config-env.js
+++ b/test/config-env.js
@@ -2,3 +2,5 @@ process.env.CONTENTFUL_ACCESS_TOKEN = "FakeTokenYouWillFail";
 process.env.CONTENTFUL_SPACE = "rhotsuly6hr2";
 process.env.JWT_SECRET = "DontUseMe";
 process.env.VERIFY_EMAIL_JWT_SECRET = "DontUseMe";
+process.env.MONGODB_URI = "mongodb://localhost";
+process.env.MONGODB_DBNAME = "goodjob-test";


### PR DESCRIPTION

## 這個 PR 是？ <!-- 必填 -->

#605 職場經驗的部份

## 有哪些 dependency？  <!-- 選填，沒有就刪掉 -->

#610 要做完，不然會找不到 `user.subscribeEmail` 欄位
#612 要跑起來，不然 viewCount 會沒有值

## 我應該從何看起？  <!-- 選填，沒有就刪掉 -->

這個 script 會先從 1000 的 viewCount 開始找
如果有文章就寄信，然後更新 `last_email_time` 的欄位
這樣到 500, 100 的時候會因為這個欄位已經被更新了而不會再寄信


## 若可以手動測試，要如何測試？ <!-- 選填 -->

- 準備好 experience 有 `view_count` 有大於 threshold，並且透過 `author_id` 找的到對應的 user
- 準備好 AWS 的環境變數，填進 .env 檔，在 root 執行 `node scripts/sendPerformanceEmail.js`
  - **要注意執行之前要把 email 換掉，不然信件會真的寄出去！**