### PR TITLE
Feat: overtime_frequency_count GraphQL API

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -196,6 +196,20 @@ enum Order {
   ASCENDING
 }
 
+type OvertimeFrequencyCount {
+  """對應到表單的「幾乎不」"""
+  seldom: Int!
+
+  """對應到表單的「偶爾」"""
+  sometimes: Int!
+
+  """對應到表單的「經常」"""
+  usually: Int!
+
+  """對應到表單的「幾乎每天」"""
+  almost_everyday: Int!
+}
+
 """發布狀態"""
 enum PublishStatus {
   published
@@ -307,6 +321,7 @@ type SalaryWorkTimeStatistics {
   has_compensatory_dayoff_count: YesNoOrUnknownCount
   has_overtime_salary_count: YesNoOrUnknownCount
   is_overtime_salary_legal_count: YesNoOrUnknownCount
+  overtime_frequency_count: OvertimeFrequencyCount
 
   """不同職業的平均薪資"""
   job_average_salaries: [JobAverageSalary!]!

--- a/src/schema/salary_work_time.js
+++ b/src/schema/salary_work_time.js
@@ -1,5 +1,6 @@
 const { gql, UserInputError } = require("apollo-server-express");
 const R = require("ramda");
+const countBy = require("lodash/countBy");
 const WorkingModel = require("../models/working_model");
 const {
     requiredNumberInRange,
@@ -234,14 +235,27 @@ const resolvers = {
                 unknown: counts["don't know"] || 0,
             };
         },
-        // TODO
-        overtime_frequency_count: () => {
-            return {
-                seldom: 0,
-                sometimes: 10,
-                usually: 4,
-                almost_everyday: 0,
-            };
+        overtime_frequency_count: salary_work_times => {
+            // 把 DB 中 overtime_frequency 的 0 ~ 3 mapping 到有語意的字串
+            const mapping = [
+                "seldom",
+                "sometimes",
+                "usually",
+                "almost_everyday",
+            ];
+            const count = countBy(
+                salary_work_times,
+                salary_work_time => mapping[salary_work_time.overtime_frequency]
+            );
+            return Object.assign(
+                {
+                    seldom: 0,
+                    sometimes: 0,
+                    usually: 0,
+                    almost_everyday: 0,
+                },
+                count
+            );
         },
         // TODO
         job_average_salaries: () => {

--- a/src/schema/salary_work_time.js
+++ b/src/schema/salary_work_time.js
@@ -32,6 +32,7 @@ const Type = gql`
         has_compensatory_dayoff_count: YesNoOrUnknownCount
         has_overtime_salary_count: YesNoOrUnknownCount
         is_overtime_salary_legal_count: YesNoOrUnknownCount
+        overtime_frequency_count: OvertimeFrequencyCount
 
         "不同職業的平均薪資"
         job_average_salaries: [JobAverageSalary!]!
@@ -74,6 +75,17 @@ const Type = gql`
         yes: Int!
         no: Int!
         unknown: Int!
+    }
+
+    type OvertimeFrequencyCount {
+        "對應到表單的「幾乎不」"
+        seldom: Int!
+        "對應到表單的「偶爾」"
+        sometimes: Int!
+        "對應到表單的「經常」"
+        usually: Int!
+        "對應到表單的「幾乎每天」"
+        almost_everyday: Int!
     }
 
     enum Gender {
@@ -220,6 +232,15 @@ const resolvers = {
                 yes: counts["yes"] || 0,
                 no: counts["no"] || 0,
                 unknown: counts["don't know"] || 0,
+            };
+        },
+        // TODO
+        overtime_frequency_count: () => {
+            return {
+                seldom: 0,
+                sometimes: 10,
+                usually: 4,
+                almost_everyday: 0,
             };
         },
         // TODO

--- a/src/schema/salary_work_time.js
+++ b/src/schema/salary_work_time.js
@@ -249,7 +249,9 @@ const resolvers = {
                 almost_everyday: 0,
             };
             salary_work_times.forEach(salary_work_time => {
-                counter[mapping[salary_work_time.overtime_frequency]] += 1;
+                if (salary_work_time.overtime_frequency !== undefined) {
+                    counter[mapping[salary_work_time.overtime_frequency]] += 1;
+                }
             });
             return counter;
         },

--- a/src/schema/salary_work_time.js
+++ b/src/schema/salary_work_time.js
@@ -1,6 +1,5 @@
 const { gql, UserInputError } = require("apollo-server-express");
 const R = require("ramda");
-const countBy = require("lodash/countBy");
 const WorkingModel = require("../models/working_model");
 const {
     requiredNumberInRange,
@@ -243,19 +242,16 @@ const resolvers = {
                 "usually",
                 "almost_everyday",
             ];
-            const count = countBy(
-                salary_work_times,
-                salary_work_time => mapping[salary_work_time.overtime_frequency]
-            );
-            return Object.assign(
-                {
-                    seldom: 0,
-                    sometimes: 0,
-                    usually: 0,
-                    almost_everyday: 0,
-                },
-                count
-            );
+            const counter = {
+                seldom: 0,
+                sometimes: 0,
+                usually: 0,
+                almost_everyday: 0,
+            };
+            salary_work_times.forEach(salary_work_time => {
+                counter[mapping[salary_work_time.overtime_frequency]] += 1;
+            });
+            return counter;
         },
         // TODO
         job_average_salaries: () => {


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

新增加班頻率的統計 GraphQL API （包含 schema & 實作）

這塊會用到
<img width="292" alt="下載 (2)" src="https://user-images.githubusercontent.com/3805975/67155862-6b4ecf80-f349-11e9-9964-484579b99a14.png">

## 若可以手動測試，要如何測試？ <!-- 選填 -->

- [ ] docker-compose up 
- [ ] http://localhost:12000
- [ ] 測試 `單一公司的加班頻率統計`

```
query {
  company (name: "聯發科") {
    salary_work_time_statistics {
      overtime_frequency_count {
        seldom
        sometimes
        usually
        almost_everyday
      }
    }
  }
}
```

- [ ] 測試 `單一職業的加班頻率統計`
```
query {
  job_title(name: "軟體工程師") {
    salary_work_time_statistics {
      overtime_frequency_count {
        seldom
        sometimes
        usually
        almost_everyday
      }
    }
  }
}
```
