### PR TITLE
Hotfix: google login

### DIFF
--- a/src/models/user_model.js
+++ b/src/models/user_model.js
@@ -1,3 +1,4 @@
+const Joi = require("joi");
 /*
  * User {
  *   _id            : ObjectId!
@@ -27,14 +28,34 @@ class UserModel {
         return user;
     }
 
-    async create({ name, facebook_id, facebook, email, google_id, google }) {
+    async create(user) {
+        const userSchema = Joi.object()
+            .keys({
+                name: Joi.string()
+                    .min(1)
+                    .required(),
+                facebook_id: Joi.string(),
+                facebook: Joi.object(),
+                google_id: Joi.string(),
+                google: Joi.object(),
+                email: Joi.string()
+                    .email()
+                    .required(),
+            })
+            // facebook_id & facebook 這兩個欄位必須同時存在
+            .and("facebook_id", "facebook")
+            // google_id & google 這兩個欄位必須同時存在
+            .and("google_id", "google")
+            // facebook_id & google_id 其中一個欄位必須存在
+            .or("facebook_id", "google_id");
+
+        const result = Joi.validate(user, userSchema);
+        if (result.error !== null) {
+            throw Error(result.error);
+        }
+
         const new_user = {
-            name,
-            facebook_id,
-            facebook,
-            google_id,
-            google,
-            email,
+            ...user,
             email_status: "UNVERIFIED",
         };
 

--- a/src/routes/auth/index.js
+++ b/src/routes/auth/index.js
@@ -99,11 +99,14 @@ router.post(
 
         // Retrieve User from DB
         const google_id = account.sub;
+
         let user = await user_model.findOneByGoogleId(google_id);
         if (!user) {
             user = await user_model.create({
+                name: account.name,
                 google_id,
                 google: account,
+                email: account.email,
             });
         }
 

--- a/src/routes/auth/index.test.js
+++ b/src/routes/auth/index.test.js
@@ -29,11 +29,13 @@ describe("Auth", () => {
 
         before(async () => {
             fake_user = await user_model.create({
+                name: "markLin",
                 facebook_id: "-1",
                 facebook: {
                     id: "-1",
                     name: "markLin",
                 },
+                email: userEmail,
             });
         });
 


### PR DESCRIPTION
Close #639 

## 這個 PR 是？ <!-- 必填 -->

production 上的 google login 其實現在無法運作。
原因是 user_model.create 的地方，會取到 facebook_id, facebook 欄位（但都為 undefined），硬要塞到 mongodb 裡面變 null ，而 facebook_id 這個欄位是有建 unique index 的，造成無法正常新增使用者

這邊改變 user_model.create 的實作方法。先用 ...user 避免去取 undefined 的欄位，然後也加上 joi validation ，初步檢查欄位是否正確。

## 我應該從何看起？  <!-- 選填，沒有就刪掉 -->
by commit 

## 若可以手動測試，要如何測試？ <!-- 選填 -->

- [ ] 後端 `docker-compose up` 跑起來
- [ ] 前端 `RAZZLE_API_HOST=http://localhost:12000 yarn start` 跑起來
- [ ] 嘗試 google 登入看看，然後換個 google 帳號再登入看看，應該要正常
