### PR TITLE
Fix author in workings collections

### DIFF
--- a/src/database/migrations/index.js
+++ b/src/database/migrations/index.js
@@ -26,4 +26,5 @@ module.exports = [
     "migration-2019-07-02-add-missing-report-count",
     "migration-2019-10-10-move-workings-email-to-subscribe-email",
     "migration-2019-11-28-update-user-name",
+    "migration-2019-12-04-normalize-working-author",
 ];

--- a/src/database/migrations/migration-2019-12-04-normalize-working-author.js
+++ b/src/database/migrations/migration-2019-12-04-normalize-working-author.js
@@ -11,7 +11,7 @@ module.exports = async db => {
 
     console.log("expected nModified:", salary_work_times.length);
 
-    // update each salary_work_time.author_id
+    // update each salary_work_time.user_id
     const bulk_ops = db.collection("workings").initializeOrderedBulkOp();
     for (let salary_work_time of salary_work_times) {
         const facebook_id = salary_work_time.author.id;
@@ -19,9 +19,9 @@ module.exports = async db => {
         const user = await db.collection("users").findOne({ facebook_id });
 
         if (user) {
-            const author_id = user._id;
+            const user_id = user._id;
             bulk_ops.find({ _id: salary_work_time._id }).update({
-                $set: { author_id },
+                $set: { user_id },
             });
         }
     }

--- a/src/database/migrations/migration-2019-12-04-normalize-working-author.js
+++ b/src/database/migrations/migration-2019-12-04-normalize-working-author.js
@@ -1,0 +1,31 @@
+module.exports = async db => {
+    console.log(await db.collection("workings").count());
+
+    const salary_work_times = await db
+        .collection("workings")
+        .find({
+            "author.id": { $exists: true },
+            "author.type": "facebook",
+        })
+        .toArray();
+
+    console.log("expected nModified:", salary_work_times.length);
+
+    // update each salary_work_time.author_id
+    const bulk_ops = db.collection("workings").initializeOrderedBulkOp();
+    for (let salary_work_time of salary_work_times) {
+        const facebook_id = salary_work_time.author.id;
+
+        const user = await db.collection("users").findOne({ facebook_id });
+
+        if (user) {
+            const author_id = user._id;
+            bulk_ops.find({ _id: salary_work_time._id }).update({
+                $set: { author_id },
+            });
+        }
+    }
+    const bulk_write_result = await bulk_ops.execute();
+    console.log("ok:", bulk_write_result.ok);
+    console.log("nModified:", bulk_write_result.nModified);
+};

--- a/src/libs/authorization.js
+++ b/src/libs/authorization.js
@@ -1,13 +1,13 @@
 const _redis = require("./redis");
 const permission = require("./search-permission");
 
-function _checkPermission(mongodb, redisdb, user) {
+function _checkPermission(mongodb, redisdb, user_id) {
     return permission
-        .resolveSearchPermission(mongodb, user)
+        .resolveSearchPermission(mongodb, user_id)
         .then(hasSearchPermission => {
             if (hasSearchPermission === true) {
                 return _redis
-                    .redisSetPermission(redisdb, `${user.type}_${user.id}`)
+                    .redisSetPermission(redisdb, `${user_id.toString()}`)
                     .catch(() => {})
                     .then(() => true);
             }
@@ -18,20 +18,20 @@ function _checkPermission(mongodb, redisdb, user) {
 /*
  * @param mongodb mongo db
  * @param redisdb redis db
- * @param user    {id, type}
+ * @param user_id ObjectId
  *
  * @fulfilled true || false
  * @rejected  error
  */
-function cachedSearchPermissionAuthorization(mongodb, redisdb, user) {
-    return _redis.redisGetPermission(redisdb, `${user.type}_${user.id}`).then(
+function cachedSearchPermissionAuthorization(mongodb, redisdb, user_id) {
+    return _redis.redisGetPermission(redisdb, `${user_id.toString()}`).then(
         hasPermission => {
             if (hasPermission === true) {
                 return true;
             }
-            return _checkPermission(mongodb, redisdb, user);
+            return _checkPermission(mongodb, redisdb, user_id);
         },
-        () => _checkPermission(mongodb, redisdb, user)
+        () => _checkPermission(mongodb, redisdb, user_id)
     );
 }
 

--- a/src/libs/search-permission.js
+++ b/src/libs/search-permission.js
@@ -1,7 +1,5 @@
-async function getDataNumOfUser(db, user) {
-    const result = await db
-        .collection("users")
-        .findOne({ facebook_id: user.id });
+async function getDataNumOfUser(db, user_id) {
+    const result = await db.collection("users").findOne({ _id: user_id });
 
     if (result) {
         return result.time_and_salary_count || 0;
@@ -9,8 +7,17 @@ async function getDataNumOfUser(db, user) {
     return 0;
 }
 
-async function getRefNumOfUser(db, user) {
-    const result = await db.collection("recommendations").findOne({ user });
+async function getRefNumOfUser(db, user_id) {
+    const user = await db.collection("users").findOne({ _id: user_id });
+    if (!user) {
+        return 0;
+    }
+    if (!user.facebook_id) {
+        return 0;
+    }
+    const result = await db
+        .collection("recommendations")
+        .findOne({ user: { id: user.facebook_id, type: "facebook" } });
 
     if (result) {
         return result.count || 0;
@@ -18,27 +25,20 @@ async function getRefNumOfUser(db, user) {
     return 0;
 }
 
-async function getExperienceOfUser(db, legacy_user) {
-    const facebook_id = legacy_user.id;
-
-    const user = await db.collection("users").findOne({ facebook_id });
-
-    if (user) {
-        const result = await db
-            .collection("experiences")
-            .findOne({ author_id: user._id });
-        return result ? 1 : 0;
-    }
-    return 0;
+async function getExperienceOfUser(db, user_id) {
+    const result = await db
+        .collection("experiences")
+        .findOne({ author_id: user_id });
+    return result ? 1 : 0;
 }
 
-function resolveSearchPermission(db, user) {
+function resolveSearchPermission(db, user_id) {
     // get required values
     return (
         Promise.all([
-            getDataNumOfUser(db, user),
-            getRefNumOfUser(db, user),
-            getExperienceOfUser(db, user),
+            getDataNumOfUser(db, user_id),
+            getRefNumOfUser(db, user_id),
+            getExperienceOfUser(db, user_id),
         ])
             // determine authorization
             .then(values => {

--- a/src/libs/search-permission.test.js
+++ b/src/libs/search-permission.test.js
@@ -31,15 +31,17 @@ describe("Permission Library", () => {
         describe(`correctly authorize user with ${JSON.stringify(
             data
         )}`, () => {
+            let user_id = new ObjectId();
+
             before(async () => {
                 // insert test data into db
                 if (data.counts) {
                     await db.collection("users").insert({
+                        _id: user_id,
                         facebook_id: "peter.shih",
                         time_and_salary_count:
                             data.counts.time_and_salary_count,
                     });
-
                     await db.collection("recommendations").insert({
                         user: {
                             id: "peter.shih",
@@ -47,17 +49,17 @@ describe("Permission Library", () => {
                         },
                         count: data.counts.reference_count,
                     });
+                } else {
+                    await db.collection("users").insert({
+                        _id: user_id,
+                        facebook_id: "peter.shih",
+                    });
                 }
             });
 
             it("search permission for user", () => {
-                const user = {
-                    id: "peter.shih",
-                    type: "facebook",
-                };
-
                 return assert.becomes(
-                    permission.resolveSearchPermission(db, user),
+                    permission.resolveSearchPermission(db, user_id),
                     data.expected
                 );
             });
@@ -70,8 +72,9 @@ describe("Permission Library", () => {
     });
 
     describe("shared experiences", () => {
+        let user_id = new ObjectId();
+
         before(async () => {
-            const user_id = ObjectId();
             await db.collection("users").insertOne({
                 _id: user_id,
                 facebook_id: "power.id",
@@ -82,12 +85,9 @@ describe("Permission Library", () => {
         });
 
         it("search permission for user", async () => {
-            const user = {
-                id: "power.id",
-                type: "facebook",
-            };
-
-            assert.isTrue(await permission.resolveSearchPermission(db, user));
+            assert.isTrue(
+                await permission.resolveSearchPermission(db, user_id)
+            );
         });
 
         after(async () => {

--- a/src/middlewares/authorization.js
+++ b/src/middlewares/authorization.js
@@ -9,13 +9,10 @@ function cachedSearchPermissionAuthorizationMiddleware(req, res, next) {
         next(new HttpError("Forbidden", 403));
     }
 
-    const old_user = {
-        id: req.user.facebook_id,
-        type: "facebook",
-    };
+    const user_id = req.user._id;
 
     authorization
-        .cachedSearchPermissionAuthorization(db, redis_client, old_user)
+        .cachedSearchPermissionAuthorization(db, redis_client, user_id)
         .then(
             hasPermission => {
                 if (hasPermission === true) {

--- a/src/middlewares/authorization.test.js
+++ b/src/middlewares/authorization.test.js
@@ -108,10 +108,10 @@ describe("Authorization middleware", () => {
     });
 
     describe("redis cached", () => {
-        const user_ids = [new ObjectId(), new ObjectId()];
+        const user_ids = [new ObjectId(), new ObjectId(), new ObjectId()];
 
         before(done => {
-            redis_client.set("permission_facebook_peter.shih", "1", done);
+            redis_client.set(`permission_${user_ids[2].toString()}`, "1", done);
         });
 
         before(() =>
@@ -132,7 +132,7 @@ describe("Authorization middleware", () => {
         it("success if redis cached", done => {
             const req = {
                 user: {
-                    _id: new ObjectId(),
+                    _id: user_ids[2],
                     facebook_id: "peter.shih",
                 },
                 db,

--- a/src/routes/experiences/testData.js
+++ b/src/routes/experiences/testData.js
@@ -101,10 +101,6 @@ function generateWorkExperienceData() {
 
 function generateWorkingData() {
     return {
-        author: {
-            type: "facebook",
-            _id: new ObjectId(),
-        },
         created_at: new Date(),
         company: {
             id: "123456789",

--- a/src/routes/me/permissions.test.js
+++ b/src/routes/me/permissions.test.js
@@ -1,6 +1,7 @@
 const { assert } = require("chai");
 const sinon = require("sinon");
 const request = require("supertest");
+const { ObjectId } = require("mongodb");
 
 const app = require("../../app");
 const { FakeUserFactory } = require("../../utils/test_helper");
@@ -19,14 +20,12 @@ describe("GET /me/permission/search 確認使用者查詢資訊權限", () => {
     });
 
     it("hasSearchPermission is true", async () => {
-        const token = await fake_user_factory.create({ facebook_id: "-1" });
+        const user = { _id: new ObjectId(), facebook_id: "-1" };
+        const token = await fake_user_factory.create(user);
 
         const cachedSearchPermissionAuthorization = sandbox
             .stub(authorization, "cachedSearchPermissionAuthorization")
-            .withArgs(sinon.match.object, sinon.match.object, {
-                id: "-1",
-                type: "facebook",
-            })
+            .withArgs(sinon.match.object, sinon.match.object, user._id)
             .resolves(true);
 
         const res = await request(app)

--- a/src/routes/me/workings/index.js
+++ b/src/routes/me/workings/index.js
@@ -42,7 +42,7 @@ router.get("/", [
     wrap(async (req, res) => {
         const user_id = req.user._id;
         const query = {
-            author_id: user_id,
+            user_id,
         };
 
         const working_model = new WorkingModel(req.db);

--- a/src/routes/me/workings/index.js
+++ b/src/routes/me/workings/index.js
@@ -40,9 +40,9 @@ const WorkingModel = require("../../../models/working_model");
 router.get("/", [
     requireUserAuthetication,
     wrap(async (req, res) => {
-        const user = req.user;
+        const user_id = req.user._id;
         const query = {
-            "author.id": user.facebook_id,
+            author_id: user_id,
         };
 
         const working_model = new WorkingModel(req.db);

--- a/src/routes/me/workings/index.test.js
+++ b/src/routes/me/workings/index.test.js
@@ -47,17 +47,11 @@ describe("Get /me/workings ", () => {
 
     before("Create Data", async () => {
         const user_working = Object.assign(generateWorkingData(), {
-            author: {
-                type: "facebook",
-                id: fake_user.facebook_id,
-            },
+            author_id: fake_user._id,
         });
 
         const other_user_working = Object.assign(generateWorkingData(), {
-            author: {
-                type: "facebook",
-                id: fake_other_user.facebook_id,
-            },
+            author_id: fake_other_user._id,
         });
 
         const workings = await db

--- a/src/routes/me/workings/index.test.js
+++ b/src/routes/me/workings/index.test.js
@@ -47,11 +47,11 @@ describe("Get /me/workings ", () => {
 
     before("Create Data", async () => {
         const user_working = Object.assign(generateWorkingData(), {
-            author_id: fake_user._id,
+            user_id: fake_user._id,
         });
 
         const other_user_working = Object.assign(generateWorkingData(), {
-            author_id: fake_other_user._id,
+            user_id: fake_other_user._id,
         });
 
         const workings = await db

--- a/src/routes/workings/helper.js
+++ b/src/routes/workings/helper.js
@@ -11,14 +11,12 @@ const { shouldIn } = require("../../libs/validation");
  * Fullfilled with newest queries_count
  * Rejected with HttpError
  */
-function checkAndUpdateQuota(db, author) {
+function checkAndUpdateQuota(db, user_id) {
     const collection = db.collection("users");
     const quota = 5;
 
-    const provider = `${author.type}_id`;
-
     const filter = {
-        [provider]: author.id,
+        _id: user_id,
     };
 
     function increment() {

--- a/src/routes/workings/helper.test.js
+++ b/src/routes/workings/helper.test.js
@@ -18,25 +18,22 @@ describe("Workings Helper", () => {
         before("Seeding", () =>
             db.collection("users").insertMany([
                 {
-                    facebook_id: "001",
+                    _id: "AAA",
                     time_and_salary_count: 4,
                 },
                 {
-                    facebook_id: "002",
+                    _id: "BBB",
                     time_and_salary_count: 5,
                 },
             ])
         );
 
         it("fulfilled with queries_count if quota is OK", () =>
-            assert.becomes(
-                helper.checkAndUpdateQuota(db, { id: "001", type: "facebook" }),
-                5
-            ));
+            assert.becomes(helper.checkAndUpdateQuota(db, "AAA"), 5));
 
         it("rejected with HttpError if quota is reached", () =>
             assert.isRejected(
-                helper.checkAndUpdateQuota(db, { id: "001", type: "facebook" }),
+                helper.checkAndUpdateQuota(db, "BBB"),
                 HttpError
             ));
 

--- a/src/routes/workings/index.js
+++ b/src/routes/workings/index.js
@@ -269,7 +269,7 @@ router.patch("/:id", [
             throw err;
         }
 
-        if (!working.author_id.equals(user._id)) {
+        if (!working.user_id.equals(user._id)) {
             throw new HttpError("user is unauthorized", 403);
         }
 

--- a/src/routes/workings/index.js
+++ b/src/routes/workings/index.js
@@ -249,6 +249,7 @@ function _isValidStatus(value) {
 router.patch("/:id", [
     requireUserAuthetication,
     wrap(async (req, res) => {
+        // TODO-Work
         const id = req.params.id;
         const status = req.body.status;
         const user = req.user;
@@ -268,7 +269,7 @@ router.patch("/:id", [
             throw err;
         }
 
-        if (!(working.author.id === user.facebook_id)) {
+        if (!working.author_id.equals(user._id)) {
             throw new HttpError("user is unauthorized", 403);
         }
 

--- a/src/routes/workings/index.test.js
+++ b/src/routes/workings/index.test.js
@@ -274,11 +274,11 @@ describe("Workings 工時資訊", () => {
         before("Seeding some workings", async () => {
             const user_working = Object.assign(generateWorkingData(), {
                 status: "published",
-                author_id: fake_user._id,
+                user_id: fake_user._id,
             });
             const other_user_working = Object.assign(generateWorkingData(), {
                 status: "published",
-                author_id: fake_other_user._id,
+                user_id: fake_other_user._id,
             });
             const result = await db
                 .collection("workings")

--- a/src/routes/workings/index.test.js
+++ b/src/routes/workings/index.test.js
@@ -274,17 +274,11 @@ describe("Workings 工時資訊", () => {
         before("Seeding some workings", async () => {
             const user_working = Object.assign(generateWorkingData(), {
                 status: "published",
-                author: {
-                    type: "facebook",
-                    id: fake_user.facebook_id,
-                },
+                author_id: fake_user._id,
             });
             const other_user_working = Object.assign(generateWorkingData(), {
                 status: "published",
-                author: {
-                    type: "facebook",
-                    id: fake_other_user.facebook_id,
-                },
+                author_id: fake_other_user._id,
             });
             const result = await db
                 .collection("workings")

--- a/src/routes/workings/workings_post.js
+++ b/src/routes/workings/workings_post.js
@@ -24,24 +24,12 @@ function checkBodyField(req, field) {
  * req.custom.company_query
  */
 function collectData(req, res, next) {
-    req.custom.author = {};
-    const author = req.custom.author;
     req.custom.working = {
-        author,
+        author_id: req.user._id,
         company: {},
         created_at: new Date(),
     };
     const working = req.custom.working;
-
-    if (checkBodyField(req, "email")) {
-        author.email = req.body.email;
-    }
-
-    if (req.user.facebook) {
-        author.id = req.user.facebook.id;
-        author.name = req.user.facebook.name;
-        author.type = "facebook";
-    }
 
     // pick these fields only
     // make sure the field is string
@@ -503,17 +491,17 @@ async function main(req, res) {
             working.recommended_by = req.custom.recommendation_string;
         }
 
-        const author = working.author;
+        const author_id = working.author_id;
 
         working.archive = {
             is_archived: false,
             reason: "",
         };
 
-        const queries_count = await helper.checkAndUpdateQuota(req.db, {
-            id: author.id,
-            type: author.type,
-        });
+        const queries_count = await helper.checkAndUpdateQuota(
+            req.db,
+            author_id
+        );
         response_data.queries_count = queries_count;
 
         await collection.insert(working);
@@ -531,6 +519,7 @@ async function main(req, res) {
         });
         // delete some sensitive information before sending response
         delete response_data.working.recommended_by;
+        delete response_data.working.author_id;
 
         res.send(response_data);
     } catch (err) {

--- a/src/routes/workings/workings_post.js
+++ b/src/routes/workings/workings_post.js
@@ -25,7 +25,7 @@ function checkBodyField(req, field) {
  */
 function collectData(req, res, next) {
     req.custom.working = {
-        author_id: req.user._id,
+        user_id: req.user._id,
         company: {},
         created_at: new Date(),
     };
@@ -491,17 +491,14 @@ async function main(req, res) {
             working.recommended_by = req.custom.recommendation_string;
         }
 
-        const author_id = working.author_id;
+        const user_id = working.user_id;
 
         working.archive = {
             is_archived: false,
             reason: "",
         };
 
-        const queries_count = await helper.checkAndUpdateQuota(
-            req.db,
-            author_id
-        );
+        const queries_count = await helper.checkAndUpdateQuota(req.db, user_id);
         response_data.queries_count = queries_count;
 
         await collection.insert(working);
@@ -519,7 +516,7 @@ async function main(req, res) {
         });
         // delete some sensitive information before sending response
         delete response_data.working.recommended_by;
-        delete response_data.working.author_id;
+        delete response_data.working.user_id;
 
         res.send(response_data);
     } catch (err) {

--- a/src/routes/workings/workings_post.test.js
+++ b/src/routes/workings/workings_post.test.js
@@ -182,9 +182,15 @@ describe("POST /workings", () => {
                 .expect(200);
 
             assert.equal(res.body.working.status, "published");
-            assert.deepPropertyVal(res.body, "working.author.id", "-1");
-            assert.deepPropertyVal(res.body, "working.author.name", "mark");
-            assert.deepPropertyVal(res.body, "working.author.type", "facebook");
+            assert.notProperty(res.body.working, "author_id");
+            assert.notProperty(res.body.working, "recommended_by");
+
+            const working = await db
+                .collection("workings")
+                .findOne({ _id: ObjectId(res.body.working._id) });
+
+            // expected fields in db
+            assert.deepEqual(working.author_id, fake_user._id);
         });
 
         it("generateSalaryRelatedPayload", async () => {
@@ -1405,48 +1411,6 @@ describe("POST /workings", () => {
             assert.equal(res2.body.queries_count, 2);
             assert.equal(res2.body.working.company.id, "00000001");
             assert.equal(res2.body.working.company.name, "GOODJOB");
-        });
-    });
-
-    describe("Checking email field", () => {
-        it("should upload emails fields while uploading worktime related data and email is given", async () => {
-            const test_email = "test12345@gmail.com";
-            const res = await request(app)
-                .post("/workings")
-                .send(
-                    generateWorkingTimeRelatedPayload({
-                        email: test_email,
-                    })
-                )
-                .set("Authorization", `Bearer ${fake_user_token}`)
-                .expect(200);
-            assert.propertyVal(res.body.working.author, "email", test_email);
-        });
-        it("should upload emails fields while uploading salary related data and email is given", async () => {
-            const test_email = "test12345@gmail.com";
-            const res = await request(app)
-                .post("/workings")
-                .send(
-                    generateSalaryRelatedPayload({
-                        email: test_email,
-                    })
-                )
-                .set("Authorization", `Bearer ${fake_user_token}`)
-                .expect(200);
-            assert.propertyVal(res.body.working.author, "email", test_email);
-        });
-        it("should upload emails fields while uploading all data and email is given", async () => {
-            const test_email = "test12345@gmail.com";
-            const res = await request(app)
-                .post("/workings")
-                .send(
-                    generateAllPayload({
-                        email: test_email,
-                    })
-                )
-                .set("Authorization", `Bearer ${fake_user_token}`)
-                .expect(200);
-            assert.propertyVal(res.body.working.author, "email", test_email);
         });
     });
 

--- a/src/routes/workings/workings_post.test.js
+++ b/src/routes/workings/workings_post.test.js
@@ -182,7 +182,7 @@ describe("POST /workings", () => {
                 .expect(200);
 
             assert.equal(res.body.working.status, "published");
-            assert.notProperty(res.body.working, "author_id");
+            assert.notProperty(res.body.working, "user_id");
             assert.notProperty(res.body.working, "recommended_by");
 
             const working = await db
@@ -190,7 +190,7 @@ describe("POST /workings", () => {
                 .findOne({ _id: ObjectId(res.body.working._id) });
 
             // expected fields in db
-            assert.deepEqual(working.author_id, fake_user._id);
+            assert.deepEqual(working.user_id, fake_user._id);
         });
 
         it("generateSalaryRelatedPayload", async () => {

--- a/src/schema/user.js
+++ b/src/schema/user.js
@@ -118,7 +118,7 @@ const resolvers = {
         },
         async salary_work_times(user, args, { db }) {
             const query = {
-                author_id: user._id,
+                user_id: user._id,
             };
 
             const working_model = new WorkingModel(db);
@@ -128,7 +128,7 @@ const resolvers = {
         },
         async salary_work_time_count(user, args, { db }) {
             const query = {
-                author_id: user._id,
+                user_id: user._id,
             };
 
             const working_model = new WorkingModel(db);

--- a/src/schema/user.js
+++ b/src/schema/user.js
@@ -118,7 +118,7 @@ const resolvers = {
         },
         async salary_work_times(user, args, { db }) {
             const query = {
-                "author.id": user.facebook_id,
+                author_id: user._id,
             };
 
             const working_model = new WorkingModel(db);
@@ -128,7 +128,7 @@ const resolvers = {
         },
         async salary_work_time_count(user, args, { db }) {
             const query = {
-                "author.id": user.facebook_id,
+                author_id: user._id,
             };
 
             const working_model = new WorkingModel(db);


### PR DESCRIPTION
幫補 readme

- workings collection 儲存的 author 是靠 Facebook id 去解析( eg: `{id: 123, name: 'Yen-chi', provider: 'facebook'}` )，當 google 帳號引進後，由於沒有 Facebook id，會引發 User 身份與 workings 的 author 對不上的情況

Before PR, 有幾個影響：
- google 登入的人不能上傳 workings (格式會錯亂)
- 個人頁面取得自己分享的新時資訊時，會撈出所有 workings 內 author.id is null 的資料 (可能會看到別人的資料)

