### PR TITLE
Feat: 所有有資料的公司和職稱列表

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -224,6 +224,9 @@ type Query {
   search_companies(query: String!): [Company!]!
   company(name: String!): Company
 
+  """列出所有有資料(薪資工時、職場經驗)的公司"""
+  companies_having_data: [Company!]!
+
   """目前用途：取得薪資資料前 topN 多的公司，且至少有三種職稱各至少有三筆資料"""
   popular_companies(limit: Int = 5): [Company!]!
 
@@ -237,6 +240,9 @@ type Query {
   job_title_keywords(limit: Int = 5): [String!]!
   search_job_titles(query: String!): [JobTitle!]!
   job_title(name: String!): JobTitle
+
+  """列出所有有資料(薪資工時、職場經驗)的職稱"""
+  job_titles_having_data: [JobTitle!]!
 
   """目前用途：取得薪資資料前 topN 多的職稱"""
   popular_job_titles(limit: Int = 5): [JobTitle!]!

--- a/src/schema/company.js
+++ b/src/schema/company.js
@@ -1,5 +1,6 @@
 const { gql } = require("apollo-server-express");
 const escapeRegExp = require("lodash/escapeRegExp");
+const { union } = require("lodash");
 
 const Type = gql`
     type Company {
@@ -21,6 +22,9 @@ const Query = gql`
     extend type Query {
         search_companies(query: String!): [Company!]!
         company(name: String!): Company
+
+        "列出所有有資料(薪資工時、職場經驗)的公司"
+        companies_having_data: [Company!]!
 
         "目前用途：取得薪資資料前 topN 多的公司，且至少有三種職稱各至少有三筆資料"
         popular_companies(limit: Int = 5): [Company!]!
@@ -89,6 +93,29 @@ const resolvers = {
             } else {
                 return null;
             }
+        },
+        companies_having_data: async (_, __, ctx) => {
+            const companiesFromSalaryWorkTime = await ctx.db
+                .collection("workings")
+                .distinct("company.name", {
+                    status: "published",
+                    "archive.is_archived": false,
+                });
+            const companiesFromExperiences = await ctx.db
+                .collection("experiences")
+                .distinct("company.name", {
+                    status: "published",
+                    "archive.is_archived": false,
+                });
+
+            return union(
+                companiesFromSalaryWorkTime,
+                companiesFromExperiences
+            ).map(name => {
+                return {
+                    name,
+                };
+            });
         },
         popular_companies: async () => [
             {

--- a/src/schema/job_title.js
+++ b/src/schema/job_title.js
@@ -1,5 +1,6 @@
 const { gql } = require("apollo-server-express");
 const escapeRegExp = require("lodash/escapeRegExp");
+const { union } = require("lodash");
 
 const Type = gql`
     type JobTitle {
@@ -24,6 +25,9 @@ const Query = gql`
     extend type Query {
         search_job_titles(query: String!): [JobTitle!]!
         job_title(name: String!): JobTitle
+
+        "列出所有有資料(薪資工時、職場經驗)的職稱"
+        job_titles_having_data: [JobTitle!]!
 
         "目前用途：取得薪資資料前 topN 多的職稱"
         popular_job_titles(limit: Int = 5): [JobTitle!]!
@@ -67,6 +71,29 @@ const resolvers = {
             return {
                 name: result.job_title,
             };
+        },
+        job_titles_having_data: async (_, __, ctx) => {
+            const companiesFromSalaryWorkTime = await ctx.db
+                .collection("workings")
+                .distinct("job_title", {
+                    status: "published",
+                    "archive.is_archived": false,
+                });
+            const companiesFromExperiences = await ctx.db
+                .collection("experiences")
+                .distinct("job_title", {
+                    status: "published",
+                    "archive.is_archived": false,
+                });
+
+            return union(
+                companiesFromSalaryWorkTime,
+                companiesFromExperiences
+            ).map(name => {
+                return {
+                    name,
+                };
+            });
         },
         popular_job_titles: async () => [
             {


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

這個 PR，是 for [所有公司頁](https://zpl.io/VkzEMNg) ＆[所有職業頁](https://zpl.io/awxmkzN)使用。這兩頁的目的是 SEO，不是給人使用的。

附註：因為資料分散在兩個 collection ，要 union 兩邊的公司/職稱，這個方法是目前想到最簡單的做法。而因為是這樣做，既然已經拿出資料了，乾脆一次全部回覆所有資料。

## 若可以手動測試，要如何測試？ <!-- 選填 -->

- [ ] docker-compose up
- [ ] http://localhost:12000
- [ ] 以下 query 可以正常運作即可 
```
query {
  companies_having_data {
    name
  }
  job_titles_having_data {
    name
  }
}
```
