### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ services:
 
 env:
     global:
-        - MONGODB_URI=mongodb://localhost/goodjob
+        - MONGODB_URI=mongodb://localhost
+        - MONGODB_DBNAME=goodjob
         - REDIS_URL=redis://localhost
         - NODE_ENV=test
         - JWT_SECRET=DontUseMe

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node ./bin/www",
     "dev": "nodemon ./bin/www",
-    "test": "mocha --recursive scripts/*.test.js src/**/*.test.js --require ./test/config-env.js --exit",
+    "test": "mocha --recursive \"scripts/*.test.js\" \"src/**/*.test.js\" --require ./test/config-env.js --exit",
     "test:one": "mocha --require ./test/config-env.js --exit --file",
     "lint": "eslint \"./**/*.js\"",
     "lint:fix": "npm run lint -- --fix",

--- a/test/config-env.js
+++ b/test/config-env.js
@@ -2,3 +2,5 @@ process.env.CONTENTFUL_ACCESS_TOKEN = "FakeTokenYouWillFail";
 process.env.CONTENTFUL_SPACE = "rhotsuly6hr2";
 process.env.JWT_SECRET = "DontUseMe";
 process.env.VERIFY_EMAIL_JWT_SECRET = "DontUseMe";
+process.env.MONGODB_URI = process.env.MONGODB_URI || "mongodb://localhost";
+process.env.MONGODB_DBNAME = process.env.MONGODB_DBNAME || "goodjob-test";

--- a/test/config-env.js
+++ b/test/config-env.js
@@ -2,5 +2,3 @@ process.env.CONTENTFUL_ACCESS_TOKEN = "FakeTokenYouWillFail";
 process.env.CONTENTFUL_SPACE = "rhotsuly6hr2";
 process.env.JWT_SECRET = "DontUseMe";
 process.env.VERIFY_EMAIL_JWT_SECRET = "DontUseMe";
-process.env.MONGODB_URI = "mongodb://localhost";
-process.env.MONGODB_DBNAME = "goodjob-test";


### PR DESCRIPTION


1. 原本的寫法 `src/**/*.test.js` 會導致測試無效，只跑了 ~ 106個測試，修正後變回 4xx 多個

Ref: https://stackoverflow.com/a/19902459

（原因是因為 ** 在 shell 裡面自動被展開，但應該要原封不動的送入 mocha，所以加上雙引號）

2. `test/config-env.js` 雖然是用來放測試會用到的環境變數，不過不是全部人(含 CI)的環境都是 localhost，所以採用 default value 覆蓋

