### PR TITLE
Refactor: salary work time validate

### DIFF
--- a/src/models/common_schemas.js
+++ b/src/models/common_schemas.js
@@ -1,0 +1,62 @@
+// This file is for common joi schemas
+const Joi = require("@hapi/joi");
+
+const salarySchema = Joi.object({
+    type: Joi.valid("hour", "day", "month", "year"),
+    amount: Joi.when("type", {
+        is: "hour",
+        then: Joi.number()
+            .integer()
+            .min(10)
+            .max(10000)
+            .messages({
+                "number.min":
+                    "薪資過低。可能有少填寫 0，或薪資種類(年薪/月薪/日薪/時薪)選擇錯誤，請再檢查一次",
+                "number.max":
+                    "薪資過高。可能有多填寫 0，或薪資種類(年薪/月薪/日薪/時薪)選擇錯誤，請再檢查一次",
+            }),
+    })
+        .when("type", {
+            is: "day",
+            then: Joi.number()
+                .integer()
+                .min(100)
+                .max(120000)
+                .messages({
+                    "number.min":
+                        "薪資過低。可能有少填寫 0，或薪資種類(年薪/月薪/日薪/時薪)選擇錯誤，請再檢查一次",
+                    "number.max":
+                        "薪資過高。可能有多填寫 0，或薪資種類(年薪/月薪/日薪/時薪)選擇錯誤，請再檢查一次",
+                }),
+        })
+        .when("type", {
+            is: "month",
+            then: Joi.number()
+                .integer()
+                .min(1000)
+                .max(1000000)
+                .messages({
+                    "number.min":
+                        "薪資過低。可能有少填寫 0，或薪資種類(年薪/月薪/日薪/時薪)選擇錯誤，請再檢查一次",
+                    "number.max":
+                        "薪資過高。可能有多填寫 0，或薪資種類(年薪/月薪/日薪/時薪)選擇錯誤，請再檢查一次",
+                }),
+        })
+        .when("type", {
+            is: "year",
+            then: Joi.number()
+                .integer()
+                .min(10000)
+                .max(12000000)
+                .messages({
+                    "number.min":
+                        "薪資過低。可能有少填寫 0，或薪資種類(年薪/月薪/日薪/時薪)選擇錯誤，請再檢查一次",
+                    "number.max":
+                        "薪資過高。可能有多填寫 0，或薪資種類(年薪/月薪/日薪/時薪)選擇錯誤，請再檢查一次",
+                }),
+        }),
+});
+
+module.exports = {
+    salarySchema,
+};

--- a/src/models/experience_model.js
+++ b/src/models/experience_model.js
@@ -1,62 +1,6 @@
 const mongo = require("mongodb");
 const { ObjectNotExistError } = require("../libs/errors");
-const Joi = require("@hapi/joi");
-
-const salarySchema = Joi.object({
-    type: Joi.valid("hour", "day", "month", "year"),
-    amount: Joi.when("type", {
-        is: "hour",
-        then: Joi.number()
-            .integer()
-            .min(10)
-            .max(10000)
-            .messages({
-                "number.min":
-                    "薪資過低。可能有少填寫 0，或薪資種類(年薪/月薪/日薪/時薪)選擇錯誤，請再檢查一次",
-                "number.max":
-                    "薪資過高。可能有多填寫 0，或薪資種類(年薪/月薪/日薪/時薪)選擇錯誤，請再檢查一次",
-            }),
-    })
-        .when("type", {
-            is: "day",
-            then: Joi.number()
-                .integer()
-                .min(100)
-                .max(120000)
-                .messages({
-                    "number.min":
-                        "薪資過低。可能有少填寫 0，或薪資種類(年薪/月薪/日薪/時薪)選擇錯誤，請再檢查一次",
-                    "number.max":
-                        "薪資過高。可能有多填寫 0，或薪資種類(年薪/月薪/日薪/時薪)選擇錯誤，請再檢查一次",
-                }),
-        })
-        .when("type", {
-            is: "month",
-            then: Joi.number()
-                .integer()
-                .min(1000)
-                .max(1000000)
-                .messages({
-                    "number.min":
-                        "薪資過低。可能有少填寫 0，或薪資種類(年薪/月薪/日薪/時薪)選擇錯誤，請再檢查一次",
-                    "number.max":
-                        "薪資過高。可能有多填寫 0，或薪資種類(年薪/月薪/日薪/時薪)選擇錯誤，請再檢查一次",
-                }),
-        })
-        .when("type", {
-            is: "year",
-            then: Joi.number()
-                .integer()
-                .min(10000)
-                .max(12000000)
-                .messages({
-                    "number.min":
-                        "薪資過低。可能有少填寫 0，或薪資種類(年薪/月薪/日薪/時薪)選擇錯誤，請再檢查一次",
-                    "number.max":
-                        "薪資過高。可能有多填寫 0，或薪資種類(年薪/月薪/日薪/時薪)選擇錯誤，請再檢查一次",
-                }),
-        }),
-});
+const { salarySchema } = require("./common_schemas");
 
 class ExperienceModel {
     constructor(db) {

--- a/src/models/salary_work_time_model.js
+++ b/src/models/salary_work_time_model.js
@@ -1,6 +1,6 @@
 const R = require("ramda");
 const DataLoader = require("dataloader");
-
+const { salarySchema } = require("./common_schemas");
 class SalaryWorkTimeModel {
     constructor(manager) {
         this.manager = manager;
@@ -55,6 +55,16 @@ class SalaryWorkTimeModel {
             })
             .sort({ created_at: -1 })
             .toArray();
+    }
+
+    async createSalaryWorkTime(salaryWorkTime) {
+        if (salaryWorkTime && salaryWorkTime.salary) {
+            const result = salarySchema.validate(salaryWorkTime.salary);
+            if (result.error) {
+                throw result.error;
+            }
+        }
+        return await this.collection.insertOne(salaryWorkTime);
     }
 }
 

--- a/src/routes/workings/workings_post.js
+++ b/src/routes/workings/workings_post.js
@@ -1,6 +1,5 @@
 const winston = require("winston");
 const UserModel = require("../../models/user_model");
-const ModelManager = require("../../models/manager");
 const helper = require("./helper");
 const companyHelper = require("../company_helper");
 const recommendation = require("../../libs/recommendation");
@@ -508,8 +507,7 @@ async function main(req, res) {
         const queries_count = await helper.checkAndUpdateQuota(req.db, user_id);
         response_data.queries_count = queries_count;
 
-        const { SalaryWorkTimeModel } = new ModelManager(req.db);
-        await SalaryWorkTimeModel.createSalaryWorkTime(working);
+        await req.manager.SalaryWorkTimeModel.createSalaryWorkTime(working);
 
         // update user email & subscribeEmail, if email field exists
         if (working.email) {

--- a/src/routes/workings/workings_post.js
+++ b/src/routes/workings/workings_post.js
@@ -1,5 +1,6 @@
 const winston = require("winston");
 const UserModel = require("../../models/user_model");
+const ModelManager = require("../../models/manager");
 const helper = require("./helper");
 const companyHelper = require("../company_helper");
 const recommendation = require("../../libs/recommendation");
@@ -466,7 +467,6 @@ async function normalizeData(req, res, next) {
 async function main(req, res) {
     const { working } = req.custom;
     const response_data = { working };
-    const collection = req.db.collection("workings");
 
     try {
         let rec_user = null;
@@ -508,7 +508,8 @@ async function main(req, res) {
         const queries_count = await helper.checkAndUpdateQuota(req.db, user_id);
         response_data.queries_count = queries_count;
 
-        await collection.insert(working);
+        const { SalaryWorkTimeModel } = new ModelManager(req.db);
+        await SalaryWorkTimeModel.createSalaryWorkTime(working);
 
         // update user email & subscribeEmail, if email field exists
         if (working.email) {


### PR DESCRIPTION
Close #  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

目的是檢查塞到 db 的薪資工時資料的 salary.amount 是否過大
中途做了幾件事：
1. 把 experience_model 裡面的 salarySchema 移出來到 common_schemas.js 檔案
2. SalaryWorkTimeModel 新增 createSalaryWorkTime 方法，並檢驗 salary 欄位
3. `POST /workings` 塞資料的地方，改用 SalaryWorkTimeModel

p.s.  本來還想把 `POST /workings` 改成 graphql api ，但做了發現需要的工不小，做到一半先推到這個 branch https://github.com/barry800414/WorkTimeSurvey-backend/tree/refactor/create-salary-work-time ，有興趣的人可以接著做。

## 若可以手動測試，要如何測試？ <!-- 選填 -->

- [ ] 前後端跑起來
- [ ] 新增一筆薪資工時資料，應該不能出現錯誤
- [ ] 故意把薪資數值打很高 (e.g. 時薪寫 20000），應該要出現錯誤訊息
