### PR TITLE
Feat: unlock_experience & unlock_salary_work_time

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -333,7 +333,7 @@ type Mutation {
   unlock_experience(input: ID!): Experience!
 
   """解鎖某一筆薪資工時"""
-  unlock_salary_work_times(input: ID!): SalaryWorkTime!
+  unlock_salary_work_time(input: ID!): SalaryWorkTime!
   createReplyLike(input: CreateReplyLikeInput!): CreateReplyLikePayload!
   deleteReplyLike(input: DeleteReplyLikeInput!): DeleteReplyLikePayload!
   changeSalaryWorkTimeStatus(input: ChangeSalaryWorkTimeStatusInput!): ChangeSalaryWorkTimeStatusPayload!

--- a/schema.graphql
+++ b/schema.graphql
@@ -330,10 +330,10 @@ type Mutation {
   deleteExperienceLike(input: DeleteExperienceLikeInput!): DeleteExperienceLikePayload!
 
   """解鎖某一篇職場經驗"""
-  unlock_experience(input: ID!): Experience!
+  unlockExperience(input: ID!): Experience!
 
   """解鎖某一筆薪資工時"""
-  unlock_salary_work_time(input: ID!): SalaryWorkTime!
+  unlockSalaryWorkTime(input: ID!): SalaryWorkTime!
   createReplyLike(input: CreateReplyLikeInput!): CreateReplyLikePayload!
   deleteReplyLike(input: DeleteReplyLikeInput!): DeleteReplyLikePayload!
   changeSalaryWorkTimeStatus(input: ChangeSalaryWorkTimeStatusInput!): ChangeSalaryWorkTimeStatusPayload!

--- a/src/models/salary_work_time_model.js
+++ b/src/models/salary_work_time_model.js
@@ -1,6 +1,7 @@
 const R = require("ramda");
 const DataLoader = require("dataloader");
 const { salarySchema } = require("./common_schemas");
+const { ObjectNotExistError } = require("../libs/errors");
 class SalaryWorkTimeModel {
     constructor(manager) {
         this.manager = manager;
@@ -31,6 +32,22 @@ class SalaryWorkTimeModel {
 
             return results;
         });
+    }
+
+    /**
+     * 透過 _id 來取得單筆資料
+     * @param {ObjectId} _id - salary work time id
+     * @param {object} opt - mongodb find field filter
+     * @returns {Promise}
+     *  - resolved : SalaryWorkTime object
+     *  - reject : ObjectNotExistError/Default Error
+     */
+    async findOneOrFail(_id, opt = {}) {
+        const salaryWorkTime = await this.collection.findOne({ _id }, opt);
+        if (salaryWorkTime) {
+            return salaryWorkTime;
+        }
+        throw new ObjectNotExistError("該筆薪資工時不存在");
     }
 
     async findByCompanyNames(names) {

--- a/src/models/schemas/userPointEvent.js
+++ b/src/models/schemas/userPointEvent.js
@@ -31,9 +31,12 @@ const UserPointSchema = new Schema({
             createWorkExperienceBonus,
         ],
     },
-    doc_id: {
-        type: String,
-        required: true,
+    // doc_id: {
+    //     type: String,
+    //     required: true,
+    // },
+    snapshot: {
+        type: Schema.Types.Mixed,
     },
     status: {
         type: String,
@@ -47,9 +50,8 @@ const UserPointSchema = new Schema({
         type: Date,
         required: true,
     },
-    completed_at: {
+    updated_at: {
         type: Date,
-        required: true,
     },
 });
 

--- a/src/models/schemas/userSchema.js
+++ b/src/models/schemas/userSchema.js
@@ -1,7 +1,7 @@
 const { Schema } = require("mongoose");
 const EMAIL_STATUS = require("../email_status");
 
-const unlockedExperienceSchema = new Schema({
+const unlockedDataSchema = new Schema({
     _id: {
         type: Schema.Types.ObjectId,
         required: true,
@@ -48,7 +48,8 @@ const userSchema = new Schema({
         type: Number,
         default: 0,
     },
-    unlocked_experiences: [unlockedExperienceSchema],
+    unlocked_experiences: [unlockedDataSchema],
+    unlocked_salary_work_times: [unlockedDataSchema],
 });
 
 userSchema.index(

--- a/src/models/schemas/userSchema.js
+++ b/src/models/schemas/userSchema.js
@@ -1,6 +1,17 @@
 const { Schema } = require("mongoose");
 const EMAIL_STATUS = require("../email_status");
 
+const unlockedExperienceSchema = new Schema({
+    _id: {
+        type: Schema.Types.ObjectId,
+        required: true,
+    },
+    createdAt: {
+        type: Schema.Types.Date,
+        required: true,
+    },
+});
+
 const userSchema = new Schema({
     name: {
         type: String,
@@ -37,6 +48,7 @@ const userSchema = new Schema({
         type: Number,
         default: 0,
     },
+    unlocked_experiences: [unlockedExperienceSchema],
 });
 
 userSchema.index(

--- a/src/schema/me.js
+++ b/src/schema/me.js
@@ -150,7 +150,58 @@ const resolvers = {
         ),
         unlock_salary_work_time: combineResolvers(
             isAuthenticated,
-            async () => {}
+            async (root, { input }, context) => {
+                const user = context.user;
+                // 確認 input
+                if (!ObjectId.isValid(input)) {
+                    throw new Error("參數錯誤");
+                }
+                const salaryWorkTimeId = ObjectId(input);
+
+                // 確認需要多少點數
+                const requiredPoints = taskConfig[unlockSalaryWorkTime].points;
+
+                // 確認使用者是否有足夠點數
+                if (user.points < requiredPoints) {
+                    throw new Error("點數不足");
+                }
+
+                // 確認該使用者是否已經解鎖過
+                const hasUnlocked = user.unlocked_salary_work_times.some(
+                    record => {
+                        return `${record._id}` === input;
+                    }
+                );
+                if (hasUnlocked) {
+                    throw new Error("已經解鎖該筆薪資工時資料");
+                }
+
+                // 確認該筆薪資工時是否存在
+                const salaryWorkTimeModel = context.manager.SalaryWorkTimeModel;
+                const salaryWorkTime = salaryWorkTimeModel.findOneOrFail(
+                    salaryWorkTimeId
+                );
+
+                // 進行解鎖
+                user.unlocked_salary_work_times.splice(0, 0, {
+                    _id: salaryWorkTimeId,
+                    createdAt: new Date(),
+                });
+                user.points -= requiredPoints;
+                await user.save();
+
+                // 產生 userPointEvent
+                await UserPointEvent.create({
+                    user_id: user._id,
+                    event_name: unlockSalaryWorkTime,
+                    snapshot: { salaryWorkTimeId },
+                    status: COMPLETED,
+                    points: -1 * requiredPoints,
+                    created_at: new Date(),
+                });
+
+                return salaryWorkTime;
+            }
         ),
     },
 };

--- a/src/schema/me.js
+++ b/src/schema/me.js
@@ -34,9 +34,9 @@ const Query = gql`
 const Mutation = gql`
     extend type Mutation {
         "解鎖某一篇職場經驗"
-        unlock_experience(input: ID!): Experience!
+        unlockExperience(input: ID!): Experience!
         "解鎖某一筆薪資工時"
-        unlock_salary_work_time(input: ID!): SalaryWorkTime!
+        unlockSalaryWorkTime(input: ID!): SalaryWorkTime!
     }
 `;
 
@@ -97,7 +97,7 @@ const resolvers = {
         ),
     },
     Mutation: {
-        unlock_experience: combineResolvers(
+        unlockExperience: combineResolvers(
             isAuthenticated,
             async (root, { input }, context) => {
                 const user = context.user;
@@ -148,7 +148,7 @@ const resolvers = {
                 return experience;
             }
         ),
-        unlock_salary_work_time: combineResolvers(
+        unlockSalaryWorkTime: combineResolvers(
             isAuthenticated,
             async (root, { input }, context) => {
                 const user = context.user;

--- a/src/schema/me.js
+++ b/src/schema/me.js
@@ -1,15 +1,18 @@
 const { gql } = require("apollo-server-express");
 const { combineResolvers } = require("graphql-resolvers");
+const { ObjectId } = require("mongodb");
 const { isAuthenticated } = require("../utils/resolvers");
 const {
     UserPointEvent,
     COMPLETED,
 } = require("../models/schemas/userPointEvent");
 const User = require("../models/schemas/userModel");
+const ExperienceModel = require("../models/experience_model");
 const {
     unlockExperience,
     unlockSalaryWorkTime,
 } = require("../libs/events/EventType");
+const taskConfig = require("../task-config");
 
 const Type = `
 `;
@@ -33,7 +36,7 @@ const Mutation = gql`
         "解鎖某一篇職場經驗"
         unlock_experience(input: ID!): Experience!
         "解鎖某一筆薪資工時"
-        unlock_salary_work_times(input: ID!): SalaryWorkTime!
+        unlock_salary_work_time(input: ID!): SalaryWorkTime!
     }
 `;
 
@@ -94,8 +97,58 @@ const resolvers = {
         ),
     },
     Mutation: {
-        unlock_experience: combineResolvers(isAuthenticated, async () => {}),
-        unlock_salary_work_times: combineResolvers(
+        unlock_experience: combineResolvers(
+            isAuthenticated,
+            async (root, { input }, context) => {
+                const user = context.user;
+                // 確認 input
+                if (!ObjectId.isValid(input)) {
+                    throw new Error("參數錯誤");
+                }
+                const experienceId = ObjectId(input);
+
+                // 確認需要多少點數
+                const requiredPoints = taskConfig[unlockExperience].points;
+
+                // 確認使用者是否有足夠點數
+                if (user.points < requiredPoints) {
+                    throw new Error("點數不足");
+                }
+
+                // 確認該使用者是否已經解鎖過
+                const hasUnlocked = user.unlocked_experiences.some(exp => {
+                    return `${exp._id}` === input;
+                });
+                if (hasUnlocked) {
+                    throw new Error("已經解鎖該篇文章");
+                }
+
+                // 確認該篇文張是否存在
+                const experienceModel = new ExperienceModel(context.db);
+                const experience = experienceModel.findOneOrFail(experienceId);
+
+                // 進行解鎖
+                user.unlocked_experiences.splice(0, 0, {
+                    _id: experienceId,
+                    createdAt: new Date(),
+                });
+                user.points -= requiredPoints;
+                await user.save();
+
+                // 產生 userPointEvent
+                await UserPointEvent.create({
+                    user_id: user._id,
+                    event_name: unlockExperience,
+                    snapshot: { experienceId },
+                    status: COMPLETED,
+                    points: -1 * requiredPoints,
+                    created_at: new Date(),
+                });
+
+                return experience;
+            }
+        ),
+        unlock_salary_work_time: combineResolvers(
             isAuthenticated,
             async () => {}
         ),

--- a/src/schema/me.test.js
+++ b/src/schema/me.test.js
@@ -5,7 +5,10 @@ const app = require("../app");
 const { connectMongo } = require("../models/connect");
 const { FakeUserFactory } = require("../utils/test_helper");
 const taskConfig = require("../task-config");
-const { unlockExperience } = require("../libs/events/EventType");
+const {
+    unlockExperience,
+    unlockSalaryWorkTime,
+} = require("../libs/events/EventType");
 
 describe("Query me", () => {
     const fake_user_factory = new FakeUserFactory();
@@ -112,11 +115,12 @@ describe("Mutation unlockExperience", () => {
             },
         };
 
-        await request(app)
+        const res = await request(app)
             .post("/graphql")
             .send(payload)
             .set("Authorization", `Bearer ${token}`)
             .expect(200);
+        assert.equal(res.body.errors, undefined);
 
         // 檢查 user.unlocked_experiences & user.points
         const me = await db.collection("users").findOne({ _id: userId });
@@ -173,6 +177,144 @@ describe("Mutation unlockExperience", () => {
             query: /* GraphQL */ `
                 mutation UnlockExperience($input: ID!) {
                     unlockExperience(input: $input) {
+                        id
+                    }
+                }
+            `,
+            variables: {
+                input: `${ObjectId()}`, // random id
+            },
+        };
+        const res = await request(app)
+            .post("/graphql")
+            .send(payload)
+            .set("Authorization", `Bearer ${token}`)
+            .expect(200);
+        assert.lengthOf(res.body.errors, 1);
+    });
+});
+
+describe.only("Mutation unlockSalaryWorkTime", () => {
+    const fake_user_factory = new FakeUserFactory();
+    const INITIAL_POINTS = 1000;
+    let db;
+    let userId;
+    let token;
+    let salaryWorkTimeId;
+
+    before(async () => {
+        ({ db } = await connectMongo());
+    });
+
+    beforeEach(async () => {
+        userId = ObjectId();
+        await fake_user_factory.setUp();
+        token = await fake_user_factory.create({
+            _id: userId,
+            name: "mark",
+            facebook_id: "facebook_id",
+            points: INITIAL_POINTS,
+            unlocked_salary_work_times: [],
+        });
+
+        const result = await db.collection("workings").insertOne({
+            company: {
+                id: "00000001",
+                name: "MY GOODJOB COMPANY",
+            },
+            job_title: "JOB1",
+            week_work_time: 10,
+            archive: {
+                is_archived: false,
+                reason: "",
+            },
+        });
+        salaryWorkTimeId = result.insertedId;
+    });
+
+    afterEach(async () => {
+        await fake_user_factory.tearDown();
+    });
+
+    it("successfully unlock salary work time", async () => {
+        const payload = {
+            query: /* GraphQL */ `
+                mutation UnlockSalaryWorkTime($input: ID!) {
+                    unlockSalaryWorkTime(input: $input) {
+                        id
+                    }
+                }
+            `,
+            variables: {
+                input: salaryWorkTimeId,
+            },
+        };
+
+        const res = await request(app)
+            .post("/graphql")
+            .send(payload)
+            .set("Authorization", `Bearer ${token}`)
+            .expect(200);
+        assert.equal(res.body.errors, undefined);
+
+        // 檢查 user.unlocked_experiences & user.points
+        const me = await db.collection("users").findOne({ _id: userId });
+        assert.lengthOf(me.unlocked_salary_work_times, 1);
+        assert.equal(
+            `${me.unlocked_salary_work_times[0]._id}`,
+            `${salaryWorkTimeId}`
+        );
+        assert.equal(
+            me.points,
+            INITIAL_POINTS - taskConfig[unlockSalaryWorkTime].points
+        );
+
+        // 檢查 userPointEvent
+        const userPointEvents = await db
+            .collection("user_point_events")
+            .find({ user_id: userId })
+            .toArray();
+        assert.lengthOf(userPointEvents, 1);
+        assert.equal(
+            `${userPointEvents[0].snapshot.salaryWorkTimeId}`,
+            `${salaryWorkTimeId}`
+        );
+    });
+
+    it("cannot unlock same salary work time record twice", async () => {
+        const payload = {
+            query: /* GraphQL */ `
+                mutation UnlockSalaryWorkTime($input: ID!) {
+                    unlockSalaryWorkTime(input: $input) {
+                        id
+                    }
+                }
+            `,
+            variables: {
+                input: salaryWorkTimeId,
+            },
+        };
+
+        await request(app)
+            .post("/graphql")
+            .send(payload)
+            .set("Authorization", `Bearer ${token}`)
+            .expect(200);
+
+        // call API twice, second time will be error
+        const res = await request(app)
+            .post("/graphql")
+            .send(payload)
+            .set("Authorization", `Bearer ${token}`)
+            .expect(200);
+        assert.lengthOf(res.body.errors, 1);
+    });
+
+    it("cannot unlock salary work time record that not exists", async () => {
+        const payload = {
+            query: /* GraphQL */ `
+                mutation UnlockSalaryWorkTime($input: ID!) {
+                    unlockSalaryWorkTime(input: $input) {
                         id
                     }
                 }

--- a/src/schema/me.test.js
+++ b/src/schema/me.test.js
@@ -1,6 +1,8 @@
 const { assert } = require("chai");
 const request = require("supertest");
+const { ObjectId } = require("mongodb");
 const app = require("../app");
+const { connectMongo } = require("../models/connect");
 const { FakeUserFactory } = require("../utils/test_helper");
 
 describe("Query me", () => {
@@ -46,5 +48,141 @@ describe("Query me", () => {
 
         assert.propertyVal(res.body, "data", null);
         assert.property(res.body, "errors");
+    });
+});
+
+describe("Mutation unlockExperience", () => {
+    const fake_user_factory = new FakeUserFactory();
+    let db;
+    let userId;
+    let token;
+    let experienceId;
+
+    before(async () => {
+        ({ db } = await connectMongo());
+    });
+
+    beforeEach(async () => {
+        userId = ObjectId();
+        await fake_user_factory.setUp();
+        token = await fake_user_factory.create({
+            _id: userId,
+            name: "mark",
+            facebook_id: "facebook_id",
+            points: 100,
+            unlocked_experiences: [],
+        });
+
+        const result = await db.collection("experiences").insertOne({
+            created_at: new Date(),
+            type: "work",
+            title: "ugly",
+            sections: [
+                {
+                    subtitle: "段落標題",
+                    content: "我很醜",
+                },
+            ],
+            status: "published",
+            archive: {
+                is_archived: false,
+            },
+        });
+        experienceId = result.insertedId;
+    });
+
+    afterEach(async () => {
+        await fake_user_factory.tearDown();
+    });
+
+    it("successfully unlock experience", async () => {
+        const payload = {
+            query: /* GraphQL */ `
+                mutation UnlockExperience($input: ID!) {
+                    unlockExperience(input: $input) {
+                        id
+                    }
+                }
+            `,
+            variables: {
+                input: experienceId,
+            },
+        };
+
+        // API 200
+        await request(app)
+            .post("/graphql")
+            .send(payload)
+            .set("Authorization", `Bearer ${token}`)
+            .expect(200);
+
+        // 檢查 user.unlocked_experiences & user.points
+        const me = await db.collection("users").findOne({ _id: userId });
+        assert.lengthOf(me.unlocked_experiences, 1);
+        assert.equal(`${me.unlocked_experiences[0]._id}`, `${experienceId}`);
+
+        // 檢查 userPointEvent
+        const userPointEvents = await db
+            .collection("user_point_events")
+            .find({ user_id: userId })
+            .toArray();
+        assert.lengthOf(userPointEvents, 1);
+        assert.equal(
+            `${userPointEvents[0].snapshot.experienceId}`,
+            `${experienceId}`
+        );
+    });
+
+    it("cannot unlock same experience twice", async () => {
+        const payload = {
+            query: /* GraphQL */ `
+                mutation UnlockExperience($input: ID!) {
+                    unlockExperience(input: $input) {
+                        id
+                    }
+                }
+            `,
+            variables: {
+                input: experienceId,
+            },
+        };
+
+        // API 200
+        await request(app)
+            .post("/graphql")
+            .send(payload)
+            .set("Authorization", `Bearer ${token}`)
+            .expect(200);
+
+        // call payload twice, second time will be error
+        const res = await request(app)
+            .post("/graphql")
+            .send(payload)
+            .set("Authorization", `Bearer ${token}`)
+            .expect(200);
+        assert.lengthOf(res.body.errors, 1);
+    });
+
+    it("cannot unlock experience that not exists", async () => {
+        // prepare payload
+        const payload = {
+            query: /* GraphQL */ `
+                mutation UnlockExperience($input: ID!) {
+                    unlockExperience(input: $input) {
+                        id
+                    }
+                }
+            `,
+            variables: {
+                input: `${ObjectId()}`,
+            },
+        };
+        // call api with arbitrary id
+        const res = await request(app)
+            .post("/graphql")
+            .send(payload)
+            .set("Authorization", `Bearer ${token}`)
+            .expect(200);
+        assert.lengthOf(res.body.errors, 1);
     });
 });

--- a/src/schema/me.test.js
+++ b/src/schema/me.test.js
@@ -194,7 +194,7 @@ describe("Mutation unlockExperience", () => {
     });
 });
 
-describe.only("Mutation unlockSalaryWorkTime", () => {
+describe("Mutation unlockSalaryWorkTime", () => {
     const fake_user_factory = new FakeUserFactory();
     const INITIAL_POINTS = 1000;
     let db;

--- a/src/utils/test_helper.js
+++ b/src/utils/test_helper.js
@@ -17,7 +17,7 @@ class FakeUserFactory {
     }
 
     async tearDown() {
-        await this.user_model.collection.deleteMany({});
+        await this.user_model.collection.drop();
         await this.client.close();
     }
 }


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

- user schema 更新
- mutation unlock_experience API 實作
- mutation unlock_salary_work_time API 實作

## 若可以手動測試，要如何測試？ <!-- 選填 -->

- [ ] docker-compose up
- [ ] http://localhost:12000/graphql
- [ ] 進 DB ，把使用者的 points 增加到 100
- [ ] 手動打 API 測試
- [ ] 真的懶得測試的話可以仔細看測試對不對

#### request sample
```
mutation {
  unlock_experience(input: "5eb8a8706a87f60031b136bb") {
    id
  }
}
```
header
```
{
  "Authorization": "Bearer eyJhbGciOiJIUzI1Nooxx....."
}
```

