### PR TITLE
refactor: unlocked data format

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -167,6 +167,11 @@ type ExperienceLike {
   created_at: Date!
 }
 
+type ExperienceRecord {
+  unlocked_time: Date!
+  data: Experience!
+}
+
 enum ExperienceType {
   work
   interview
@@ -522,6 +527,11 @@ type SalaryWorkTime {
   archive: Archive!
 }
 
+type SalaryWorkTimeRecord {
+  unlocked_time: Date!
+  data: SalaryWorkTime!
+}
+
 type SalaryWorkTimeStatistics {
   count: Int!
   average_week_work_time: Float
@@ -597,11 +607,11 @@ type User {
   salary_work_times: [SalaryWorkTime!]!
   salary_work_time_count: Int!
 
-  """取得已經解鎖的職場經驗列表"""
-  unlocked_experiences: [Experience!]
+  """取得已經解鎖的職場經驗記錄列表"""
+  unlocked_experience_records: [ExperienceRecord!]
 
-  """取得已經解鎖的薪資工時列表"""
-  unlocked_salary_work_times: [SalaryWorkTime!]
+  """取得已經解鎖的薪資工時紀錄列表"""
+  unlocked_salary_work_time_records: [SalaryWorkTimeRecord!]
 
   """目前擁有的積分"""
   points: Int!

--- a/src/schema/user.test.js
+++ b/src/schema/user.test.js
@@ -476,6 +476,8 @@ describe("User 解鎖資料、點數相關", () => {
     let user1Token;
     let experienceId;
     let salaryWorkTimeId;
+    const experienceUnlockedTime = new Date();
+    const salaryUnlockedTime = new Date();
 
     before(async () => {
         ({ db } = await connectMongo());
@@ -509,13 +511,13 @@ describe("User 解鎖資料、點數相關", () => {
                 unlocked_experiences: [
                     {
                         _id: experienceId,
-                        created_at: new Date(),
+                        created_at: experienceUnlockedTime,
                     },
                 ],
                 unlocked_salary_work_times: [
                     {
                         _id: salaryWorkTimeId,
-                        created_at: new Date(),
+                        created_at: salaryUnlockedTime,
                     },
                 ],
             });
@@ -530,14 +532,17 @@ describe("User 解鎖資料、點數相關", () => {
         await fakeUserFactory.tearDown();
     });
 
-    it("me.unlocked_experiences", async () => {
+    it("me.unlocked_experience_records", async () => {
         const payload = {
             query: /* GraphQL */ `
                 {
                     me {
-                        unlocked_experiences {
-                            id
-                            title
+                        unlocked_experience_records {
+                            unlocked_time
+                            data {
+                                id
+                                title
+                            }
                         }
                     }
                 }
@@ -553,23 +558,31 @@ describe("User 解鎖資料、點數相關", () => {
 
         assert.deepPropertyVal(
             res.body.data,
-            "me.unlocked_experiences[0].id",
+            "me.unlocked_experience_records[0].data.id",
             `${experienceId}`
         );
         assert.deepPropertyVal(
             res.body.data,
-            "me.unlocked_experiences[0].title",
+            "me.unlocked_experience_records[0].data.title",
             experienceTitle
+        );
+        assert.deepPropertyVal(
+            res.body.data,
+            "me.unlocked_experience_records[0].unlocked_time",
+            experienceUnlockedTime.toISOString()
         );
     });
 
-    it("me.unlocked_salary_work_times", async () => {
+    it("me.unlocked_salary_work_time_records", async () => {
         const payload = {
             query: /* GraphQL */ `
                 {
                     me {
-                        unlocked_salary_work_times {
-                            id
+                        unlocked_salary_work_time_records {
+                            unlocked_time
+                            data {
+                                id
+                            }
                         }
                     }
                 }
@@ -585,8 +598,13 @@ describe("User 解鎖資料、點數相關", () => {
 
         assert.deepPropertyVal(
             res.body.data,
-            "me.unlocked_salary_work_times[0].id",
+            "me.unlocked_salary_work_time_records[0].data.id",
             `${salaryWorkTimeId}`
+        );
+        assert.deepPropertyVal(
+            res.body.data,
+            "me.unlocked_salary_work_time_records[0].unlocked_time",
+            salaryUnlockedTime.toISOString()
         );
     });
 


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

把 unlocked_experiences 改成 unlocked_experience_records ，裡面包解鎖時間和原本的資料
同上把 unlocked_salary_work_times 改成 unlocked_salary_work_time_records 

## 若可以手動測試，要如何測試？ <!-- 選填 -->

- [ ] docker-compose up
- [ ] http://localhost:12000/graphql 打開試打
```graphql
query {
  me {
    unlocked_experience_records {
      unlocked_time
      data {
        id
        title
      }
    }
  }
}
```

```graphql
query {
  me {
    unlocked_salary_work_time_records {
      unlocked_time
      data {
        id
        job_title {
          name
        }
      }
    }
  }
}
```
